### PR TITLE
Changing BPS shutdown order to shut down ode scheduler first

### DIFF
--- a/components/bpel/org.wso2.carbon.bpel/src/main/java/org/wso2/carbon/bpel/core/internal/BPELServiceComponent.java
+++ b/components/bpel/org.wso2.carbon.bpel/src/main/java/org/wso2/carbon/bpel/core/internal/BPELServiceComponent.java
@@ -28,6 +28,7 @@ import org.wso2.carbon.bpel.core.Axis2ConfigurationContextObserverImpl;
 import org.wso2.carbon.bpel.core.BPELEngineService;
 import org.wso2.carbon.bpel.core.BPELEngineServiceImpl;
 import org.wso2.carbon.bpel.core.ode.integration.BPELSchedulerInitializer;
+import org.wso2.carbon.bpel.core.ode.integration.BPELSchedulerShutDown;
 import org.wso2.carbon.bpel.core.ode.integration.BPELServer;
 import org.wso2.carbon.bpel.core.ode.integration.BPELServerImpl;
 import org.wso2.carbon.core.ServerStartupHandler;
@@ -37,6 +38,7 @@ import org.wso2.carbon.registry.core.service.TenantRegistryLoader;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.utils.Axis2ConfigurationContextObserver;
 import org.wso2.carbon.utils.ConfigurationContextService;
+import org.wso2.carbon.utils.WaitBeforeShutdownObserver;
 
 /**
  * @scr.component name="org.wso2.carbon.bpel.BPELServiceComponent" immediate="true"
@@ -75,6 +77,9 @@ public class BPELServiceComponent {
 
             bundleContext.registerService(ServerStartupHandler.class.getName(),
                     new BPELSchedulerInitializer(), null);
+            //registering service to shutdown ode scheduler, before server shutdown
+            bundleContext.registerService(WaitBeforeShutdownObserver.class.getName(),
+                    new BPELSchedulerShutDown(), null);
 
         } catch (Throwable t) {
             log.error("Failed to activate BPEL Core bundle", t);

--- a/components/bpel/org.wso2.carbon.bpel/src/main/java/org/wso2/carbon/bpel/core/ode/integration/BPELSchedulerShutDown.java
+++ b/components/bpel/org.wso2.carbon.bpel/src/main/java/org/wso2/carbon/bpel/core/ode/integration/BPELSchedulerShutDown.java
@@ -1,0 +1,62 @@
+/**
+ *
+ * Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.bpel.core.ode.integration;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.ode.bpel.iapi.Scheduler;
+import org.wso2.carbon.bpel.core.internal.BPELServiceComponent;
+import org.wso2.carbon.utils.WaitBeforeShutdownObserver;
+
+/**
+ * ODE scheduler should be shutdown before the Hazelcast instance.
+ * This class halts the carbon server shutdown until the scheduler is shut.
+ */
+public class BPELSchedulerShutDown implements WaitBeforeShutdownObserver{
+
+    private static Log log = LogFactory.getLog(BPELSchedulerShutDown.class);
+    private static boolean status = false;
+
+    //triggered before shutting down server and shutdown the scheduler if exists
+    @Override
+    public void startingShutdown() {
+        Scheduler scheduler = ((BPELServerImpl) BPELServiceComponent.getBPELServer()).getScheduler();
+
+        if (scheduler != null) {
+            try {
+                if (log.isDebugEnabled()) {
+                    log.debug("Shutting down quartz scheduler.");
+                }
+                scheduler.shutdown();
+            } catch (Exception e) {
+                log.warn("Scheduler couldn't be shut down.", e);
+            } finally {
+                scheduler = null;
+                status = true;
+            }
+        } else {
+            status = true;
+        }
+    }
+
+    //keep blocking until the status is true
+    @Override
+    public boolean isTaskComplete() {
+        return status;
+    }
+}

--- a/components/bpel/org.wso2.carbon.bpel/src/main/java/org/wso2/carbon/bpel/core/ode/integration/BPELServerImpl.java
+++ b/components/bpel/org.wso2.carbon.bpel/src/main/java/org/wso2/carbon/bpel/core/ode/integration/BPELServerImpl.java
@@ -186,6 +186,19 @@ public final class BPELServerImpl implements BPELServer , Observer{
      * @throws Exception if error occurred while shutting down BPEL Server.
      */
     public void shutdown() throws Exception {
+        if (scheduler != null) {
+            try {
+                if (log.isDebugEnabled()) {
+                    log.debug("Shutting down quartz scheduler.");
+                }
+                scheduler.shutdown();
+            } catch (Exception e) {
+                log.warn("Scheduler couldn't be shut down.", e);
+            } finally {
+                scheduler = null;
+            }
+        }
+
         if (odeBpelServer != null) {
             try {
                 if (log.isDebugEnabled()) {
@@ -211,19 +224,6 @@ public final class BPELServerImpl implements BPELServer , Observer{
                 cronScheduler = null;
             }
 
-        }
-
-        if (scheduler != null) {
-            try {
-                if (log.isDebugEnabled()) {
-                    log.debug("Shutting down quartz scheduler.");
-                }
-                scheduler.shutdown();
-            } catch (Exception e) {
-                log.warn("Scheduler couldn't be shut down.", e);
-            } finally {
-                scheduler = null;
-            }
         }
 
         if (processStore != null) {


### PR DESCRIPTION
Registering WaitBeforeShutdownObserver service to shutdown ode scheduler first and taking ode scheduler to the top in the BPELServerImpl.shutdown() method. Resolves the issue -https://wso2.org/jira/browse/BPS-470.