### PR TITLE
Removing status column from human task explorer inbox

### DIFF
--- a/components/humantask/humantask-explorer-web/src/web/template/inboxView.jag
+++ b/components/humantask/humantask-explorer-web/src/web/template/inboxView.jag
@@ -56,7 +56,6 @@
                             <th>Type</th>
                             <th>Task Name</th>
                             <th>Subject</th>
-                            <th>Status</th>
                             <th>Priority</th>
                         </tr>
                     </thead>
@@ -70,7 +69,6 @@
                             <td><%=taskXMLList[i].NS1_NS::taskType.text()%></td>
                             <td><%=taskXMLList[i].NS1_NS::presentationName.text()%></td>
                             <td><%=taskXMLList[i].NS1_NS::presentationSubject%></td>
-                            <td><%=taskXMLList[i].NS1_NS::status%></td>
                             <td><%=taskXMLList[i].NS1_NS::priority%></td>
                         </tr>
                         <%


### PR DESCRIPTION
Removing status column from human task explorer inbox for issue - https://wso2.org/jira/browse/BPS-633.