### PR TITLE
Truncating long variables in instance view

### DIFF
--- a/components/bpel/org.wso2.carbon.bpel.ui/src/main/java/org/wso2/carbon/bpel/ui/BpelUIUtil.java
+++ b/components/bpel/org.wso2.carbon.bpel.ui/src/main/java/org/wso2/carbon/bpel/ui/BpelUIUtil.java
@@ -45,6 +45,23 @@ public final class BpelUIUtil {
     private BpelUIUtil() {
     }
 
+    /**
+     * Truncates a given text to the size specified. Appends "..." to the end.
+     * @param text
+     * @param maxSize
+     * @return Truncated string
+     */
+    public static String truncateString(String text,int maxSize) {
+        long strLength = text.length();
+        if (strLength > maxSize) {
+            if (log.isDebugEnabled()) {
+                log.debug("Limiting variable size of the instance to:"+ maxSize);
+            }
+            return text.substring(0,maxSize) + " ...";
+        }
+        return text;
+    }
+
     public static String encodeHTML(String aText) {
         final StringBuilder result = new StringBuilder();
         final StringCharacterIterator iterator = new StringCharacterIterator(aText);

--- a/components/bpel/org.wso2.carbon.bpel.ui/src/main/java/org/wso2/carbon/bpel/ui/clients/InstanceManagementServiceClient.java
+++ b/components/bpel/org.wso2.carbon.bpel.ui/src/main/java/org/wso2/carbon/bpel/ui/clients/InstanceManagementServiceClient.java
@@ -60,6 +60,20 @@ public class InstanceManagementServiceClient {
         }
     }
 
+    /**
+     * Return the BPELInstanceVariableSize allowed, defined in bps.xml
+     * @return BPELInstanceVariableSize
+     * @throws Exception
+     */
+    public int getBPELInstanceVariableSize() throws Exception {
+        try {
+            return stub.getBPELInstanceVariableSize();
+        } catch (Exception e) {
+            log.error("getBPELInstanceVariableSize operation failed", e);
+            throw e;
+        }
+    }
+
     public InstanceInfoType getInstanceInfo(long iid) throws Exception {
         try {
             return stub.getInstanceInfo(iid);

--- a/components/bpel/org.wso2.carbon.bpel.ui/src/main/java/org/wso2/carbon/bpel/ui/clients/InstanceManagementServiceClient.java
+++ b/components/bpel/org.wso2.carbon.bpel.ui/src/main/java/org/wso2/carbon/bpel/ui/clients/InstanceManagementServiceClient.java
@@ -61,15 +61,15 @@ public class InstanceManagementServiceClient {
     }
 
     /**
-     * Return the BPELInstanceVariableSize allowed, defined in bps.xml
+     * Return the InstanceViewVariableLength allowed, defined in bps.xml
      * @return BPELInstanceVariableSize
      * @throws Exception
      */
-    public int getBPELInstanceVariableSize() throws Exception {
+    public int getInstanceViewVariableLength() throws Exception {
         try {
-            return stub.getBPELInstanceVariableSize();
+            return stub.getInstanceViewVariableLength();
         } catch (Exception e) {
-            log.error("getBPELInstanceVariableSize operation failed", e);
+            log.error("getInstanceViewVariableLength operation failed", e);
             throw e;
         }
     }

--- a/components/bpel/org.wso2.carbon.bpel.ui/src/main/resources/web/bpel/instance_view.jsp
+++ b/components/bpel/org.wso2.carbon.bpel.ui/src/main/resources/web/bpel/instance_view.jsp
@@ -628,7 +628,18 @@
         //                                        PrettyXML.writeFancily(sr, sw);
         //                                        sr.close();
         //                                        varStr = sw.toString();
-                                                varStr = BpelUIUtil.encodeHTML(BpelUIUtil.prettyPrint(varValue));
+                                                try {
+                                                    //read the max variable size from configuration
+                                                    int maxSize = client.getBPELInstanceVariableSize() * 1000;
+                                                    varStr = BpelUIUtil.encodeHTML(BpelUIUtil
+                                                            .truncateString(BpelUIUtil.prettyPrint(varValue), maxSize));
+                                                } catch (Exception e) {
+
+                                                    response.setStatus(HttpStatus.SC_INTERNAL_SERVER_ERROR);
+                                                    CarbonUIMessage uiMsg = new CarbonUIMessage(CarbonUIMessage.ERROR,
+                                                            e.getMessage(), e);
+                                                    session.setAttribute(CarbonUIMessage.ID, uiMsg);
+                                                }
         //                                        varStr = varStr.replaceAll("\n", "<br/>");
 
                                             }

--- a/components/bpel/org.wso2.carbon.bpel.ui/src/main/resources/web/bpel/instance_view.jsp
+++ b/components/bpel/org.wso2.carbon.bpel.ui/src/main/resources/web/bpel/instance_view.jsp
@@ -629,8 +629,8 @@
         //                                        sr.close();
         //                                        varStr = sw.toString();
                                                 try {
-                                                    //read the max variable size from configuration
-                                                    int maxSize = client.getBPELInstanceVariableSize() * 1000;
+                                                    //read the max variable length from configuration
+                                                    int maxSize = client.getInstanceViewVariableLength() * 1000;
                                                     varStr = BpelUIUtil.encodeHTML(BpelUIUtil
                                                             .truncateString(BpelUIUtil.prettyPrint(varValue), maxSize));
                                                 } catch (Exception e) {

--- a/components/bpel/org.wso2.carbon.bpel/src/main/java/org/wso2/carbon/bpel/core/BPELConstants.java
+++ b/components/bpel/org.wso2.carbon.bpel/src/main/java/org/wso2/carbon/bpel/core/BPELConstants.java
@@ -263,7 +263,7 @@ public final class BPELConstants {
 
     public static final int DEFAULT_TIMEOUT = 120000;
 
-    public static final int DEFAULT_INSTANCE_VARIABLE_SIZE = 1000;
+    public static final int DEFAULT_INSTANCE_VIEW_VARIABLE_LENGTH = 1000;
 
     /*  added to set updated properties of a package*/
     public static final String BPEL_INSTANCE_CLEANUP_FAILURE =  "bpel.instance.cleanup.failure: ";

--- a/components/bpel/org.wso2.carbon.bpel/src/main/java/org/wso2/carbon/bpel/core/BPELConstants.java
+++ b/components/bpel/org.wso2.carbon.bpel/src/main/java/org/wso2/carbon/bpel/core/BPELConstants.java
@@ -263,6 +263,8 @@ public final class BPELConstants {
 
     public static final int DEFAULT_TIMEOUT = 120000;
 
+    public static final int DEFAULT_INSTANCE_VARIABLE_SIZE = 1000;
+
     /*  added to set updated properties of a package*/
     public static final String BPEL_INSTANCE_CLEANUP_FAILURE =  "bpel.instance.cleanup.failure: ";
     public static final String BPEL_INSTANCE_CLEANUP_SUCCESS =  "bpel.instance.cleanup.success:";

--- a/components/bpel/org.wso2.carbon.bpel/src/main/java/org/wso2/carbon/bpel/core/ode/integration/config/BPELServerConfiguration.java
+++ b/components/bpel/org.wso2.carbon.bpel/src/main/java/org/wso2/carbon/bpel/core/ode/integration/config/BPELServerConfiguration.java
@@ -30,7 +30,6 @@ import org.wso2.carbon.utils.CarbonUtils;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.text.ParseException;
 import java.util.*;
@@ -134,6 +133,9 @@ public class BPELServerConfiguration {
     private int odeSchedulerImmediateTransactionRetryLimit  = 3;
     private long odeSchedulerImmediateTransactionRetryInterval  = 1000;
 
+    //Maximum size of a BPEL variable
+    private int instanceVariableSize = BPELConstants.DEFAULT_INSTANCE_VARIABLE_SIZE;
+
     public BPELServerConfiguration() {
         if (log.isDebugEnabled()) {
             log.debug("Loading bps configuration....");
@@ -197,6 +199,10 @@ public class BPELServerConfiguration {
 
     public void setKeepAlive(boolean keepAlive) {
         this.keepAlive = keepAlive;
+    }
+
+    public int getBPELInstanceVariableSize() {
+        return instanceVariableSize;
     }
 
 
@@ -433,6 +439,7 @@ public class BPELServerConfiguration {
         populatePersistenceProvider();
         populateNodeId();
         populateODESchedulerConfiguration();
+        populateBPELInstanceVariableSize();
     }
 
     private void populateSyncWithRegistry() {
@@ -654,6 +661,13 @@ public class BPELServerConfiguration {
                 }
             }
         }
+    }
+
+    private void populateBPELInstanceVariableSize() {
+        if(bpsConfigDocument.getWSO2BPS().isSetBPELInstanceVariableSize()) {
+            this.instanceVariableSize = bpsConfigDocument.getWSO2BPS().getBPELInstanceVariableSize();
+        }
+
     }
 
     public String getPersistenceProvider() {

--- a/components/bpel/org.wso2.carbon.bpel/src/main/java/org/wso2/carbon/bpel/core/ode/integration/config/BPELServerConfiguration.java
+++ b/components/bpel/org.wso2.carbon.bpel/src/main/java/org/wso2/carbon/bpel/core/ode/integration/config/BPELServerConfiguration.java
@@ -133,8 +133,8 @@ public class BPELServerConfiguration {
     private int odeSchedulerImmediateTransactionRetryLimit  = 3;
     private long odeSchedulerImmediateTransactionRetryInterval  = 1000;
 
-    //Maximum size of a BPEL variable
-    private int instanceVariableSize = BPELConstants.DEFAULT_INSTANCE_VARIABLE_SIZE;
+    //Maximum length of a instance variable in instance view.
+    private int instanceViewVariableLength = BPELConstants.DEFAULT_INSTANCE_VIEW_VARIABLE_LENGTH;
 
     public BPELServerConfiguration() {
         if (log.isDebugEnabled()) {
@@ -201,8 +201,8 @@ public class BPELServerConfiguration {
         this.keepAlive = keepAlive;
     }
 
-    public int getBPELInstanceVariableSize() {
-        return instanceVariableSize;
+    public int getInstanceViewVariableLength() {
+        return instanceViewVariableLength;
     }
 
 
@@ -439,7 +439,7 @@ public class BPELServerConfiguration {
         populatePersistenceProvider();
         populateNodeId();
         populateODESchedulerConfiguration();
-        populateBPELInstanceVariableSize();
+        populateInstanceViewVariableLength();
     }
 
     private void populateSyncWithRegistry() {
@@ -663,9 +663,9 @@ public class BPELServerConfiguration {
         }
     }
 
-    private void populateBPELInstanceVariableSize() {
-        if(bpsConfigDocument.getWSO2BPS().isSetBPELInstanceVariableSize()) {
-            this.instanceVariableSize = bpsConfigDocument.getWSO2BPS().getBPELInstanceVariableSize();
+    private void populateInstanceViewVariableLength() {
+        if(bpsConfigDocument.getWSO2BPS().isSetInstanceViewVariableLength()) {
+            this.instanceViewVariableLength = bpsConfigDocument.getWSO2BPS().getInstanceViewVariableLength();
         }
 
     }

--- a/components/bpel/org.wso2.carbon.bpel/src/main/java/org/wso2/carbon/bpel/core/ode/integration/mgt/services/InstanceManagementServiceSkeleton.java
+++ b/components/bpel/org.wso2.carbon.bpel/src/main/java/org/wso2/carbon/bpel/core/ode/integration/mgt/services/InstanceManagementServiceSkeleton.java
@@ -315,8 +315,8 @@ public class InstanceManagementServiceSkeleton extends AbstractAdmin
      * @throws InstanceManagementException
      */
     @Override
-    public int getBPELInstanceVariableSize() throws InstanceManagementException {
-        return bpelServer.getBpelServerConfiguration().getBPELInstanceVariableSize();
+    public int getInstanceViewVariableLength() throws InstanceManagementException {
+        return bpelServer.getBpelServerConfiguration().getInstanceViewVariableLength();
     }
 
     /**

--- a/components/bpel/org.wso2.carbon.bpel/src/main/java/org/wso2/carbon/bpel/core/ode/integration/mgt/services/InstanceManagementServiceSkeleton.java
+++ b/components/bpel/org.wso2.carbon.bpel/src/main/java/org/wso2/carbon/bpel/core/ode/integration/mgt/services/InstanceManagementServiceSkeleton.java
@@ -309,6 +309,17 @@ public class InstanceManagementServiceSkeleton extends AbstractAdmin
     }
 
     /**
+     * Returns the maximum size for a variable to be displayed in the instance_view UI,
+     * defined in bps.xml.
+     * @return Maximum instance variable size
+     * @throws InstanceManagementException
+     */
+    @Override
+    public int getBPELInstanceVariableSize() throws InstanceManagementException {
+        return bpelServer.getBpelServerConfiguration().getBPELInstanceVariableSize();
+    }
+
+    /**
      * Get long running instances with duration
      *
      * @param limit The maximum number of instances to be fetched

--- a/components/bpel/org.wso2.carbon.bpel/src/main/resources/META-INF/bps_management.xsd
+++ b/components/bpel/org.wso2.carbon.bpel/src/main/resources/META-INF/bps_management.xsd
@@ -30,6 +30,7 @@
         </xsd:complexType>
     </xsd:element>
 
+    <xsd:element name="BPELInstanceVariableSize" type="xsd:int"/>
     <!--The following elements are added to describe process contents-->
     <xsd:element name="getProcessDeployDetails" type="xsd:QName"/>
     <xsd:element name="ProcessDeployDetailsList">

--- a/components/bpel/org.wso2.carbon.bpel/src/main/resources/META-INF/bps_management.xsd
+++ b/components/bpel/org.wso2.carbon.bpel/src/main/resources/META-INF/bps_management.xsd
@@ -30,7 +30,7 @@
         </xsd:complexType>
     </xsd:element>
 
-    <xsd:element name="BPELInstanceVariableSize" type="xsd:int"/>
+    <xsd:element name="InstanceViewVariableLength" type="xsd:int"/>
     <!--The following elements are added to describe process contents-->
     <xsd:element name="getProcessDeployDetails" type="xsd:QName"/>
     <xsd:element name="ProcessDeployDetailsList">

--- a/components/bpel/org.wso2.carbon.bpel/src/main/resources/META-INF/instance_mgt.wsdl
+++ b/components/bpel/org.wso2.carbon.bpel/src/main/resources/META-INF/instance_mgt.wsdl
@@ -29,6 +29,10 @@
         </xsd:schema>
     </types>
 
+    <message name="getBPELInstanceVariableSizeRequest"/>
+    <message name="getBPELInstanceVariableSizeResponse">
+        <part name="part" element="ns:BPELInstanceVariableSize"/>
+    </message>
     <message name="getPaginatedInstanceListRequest">
         <part name="part" element="ns:getPaginatedInstanceListInput"/>
     </message>
@@ -126,6 +130,11 @@
     </message>
 
     <portType name="InstanceManagementPortType">
+        <operation name="getBPELInstanceVariableSize">
+            <input message="tns:getBPELInstanceVariableSizeRequest"/>
+            <output message="tns:getBPELInstanceVariableSizeResponse"/>
+            <fault name="instanceManagementException" message="tns:instanceManagementException" />
+        </operation>
         <operation name="getPaginatedInstanceList">
             <input message="tns:getPaginatedInstanceListRequest"/>
             <output message="tns:getPaginatedInstanceListResponse"/>
@@ -201,6 +210,18 @@
     </portType>
     <binding name="InstanceManagementSOAPBinding" type="tns:InstanceManagementPortType">
         <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <operation name="getBPELInstanceVariableSize">
+            <soap:operation soapAction="urn:getBPELInstanceVariableSize"/>
+            <input>
+                <soap:body use="literal"/>
+            </input>
+            <output>
+                <soap:body use="literal"/>
+            </output>
+            <fault name="instanceManagementException">
+                <soap:fault name="instanceManagementException" use="literal"/>
+            </fault>
+        </operation>
         <operation name="getPaginatedInstanceList">
             <soap:operation soapAction="urn:getPaginatedInstanceList"/>
             <input>

--- a/components/bpel/org.wso2.carbon.bpel/src/main/resources/META-INF/instance_mgt.wsdl
+++ b/components/bpel/org.wso2.carbon.bpel/src/main/resources/META-INF/instance_mgt.wsdl
@@ -29,9 +29,9 @@
         </xsd:schema>
     </types>
 
-    <message name="getBPELInstanceVariableSizeRequest"/>
-    <message name="getBPELInstanceVariableSizeResponse">
-        <part name="part" element="ns:BPELInstanceVariableSize"/>
+    <message name="getInstanceViewVariableLengthRequest"/>
+    <message name="getInstanceViewVariableLengthResponse">
+        <part name="part" element="ns:InstanceViewVariableLength"/>
     </message>
     <message name="getPaginatedInstanceListRequest">
         <part name="part" element="ns:getPaginatedInstanceListInput"/>
@@ -130,9 +130,9 @@
     </message>
 
     <portType name="InstanceManagementPortType">
-        <operation name="getBPELInstanceVariableSize">
-            <input message="tns:getBPELInstanceVariableSizeRequest"/>
-            <output message="tns:getBPELInstanceVariableSizeResponse"/>
+        <operation name="getInstanceViewVariableLength">
+            <input message="tns:getInstanceViewVariableLengthRequest"/>
+            <output message="tns:getInstanceViewVariableLengthResponse"/>
             <fault name="instanceManagementException" message="tns:instanceManagementException" />
         </operation>
         <operation name="getPaginatedInstanceList">
@@ -210,8 +210,8 @@
     </portType>
     <binding name="InstanceManagementSOAPBinding" type="tns:InstanceManagementPortType">
         <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
-        <operation name="getBPELInstanceVariableSize">
-            <soap:operation soapAction="urn:getBPELInstanceVariableSize"/>
+        <operation name="getInstanceViewVariableLength">
+            <soap:operation soapAction="urn:getInstanceViewVariableLength"/>
             <input>
                 <soap:body use="literal"/>
             </input>

--- a/components/bpel/org.wso2.carbon.bpel/src/main/resources/META-INF/services.xml
+++ b/components/bpel/org.wso2.carbon.bpel/src/main/resources/META-INF/services.xml
@@ -248,20 +248,20 @@
         </parameter>
         <parameter name="useOriginalwsdl">true</parameter>
         <parameter name="modifyUserWSDLPortAddress">true</parameter>
-        <operation name="getBPELInstanceVariableSize" mep="http://www.w3.org/ns/wsdl/in-out"
+        <operation name="getInstanceViewVariableLength" mep="http://www.w3.org/ns/wsdl/in-out"
                    namespace="http://wso2.org/bps/management/wsdl/InstanceManagement">
             <actionMapping>urn:getBPELInstanceVariableSize</actionMapping>
             <outputActionMapping>
-                http://wso2.org/bps/management/wsdl/InstanceManagement/InstanceManagementPortType/getBPELInstanceVariableSizeResponse
+                http://wso2.org/bps/management/wsdl/InstanceManagement/InstanceManagementPortType/getInstanceViewVariableLengthResponse
             </outputActionMapping>
             <faultActionMapping faultName="instanceManagementException">
-                http://wso2.org/bps/management/wsdl/InstanceManagement/InstanceManagementPortType/getBPELInstanceVariableSize/Fault/instanceManagementException
+                http://wso2.org/bps/management/wsdl/InstanceManagement/InstanceManagementPortType/getInstanceViewVariableLength/Fault/instanceManagementException
             </faultActionMapping>
             <faultActionMapping faultName="InstanceManagementException">
-                http://wso2.org/bps/management/wsdl/InstanceManagement/InstanceManagementPortType/getBPELInstanceVariableSize/Fault/instanceManagementException
+                http://wso2.org/bps/management/wsdl/InstanceManagement/InstanceManagementPortType/getInstanceViewVariableLength/Fault/instanceManagementException
             </faultActionMapping>
             <faultActionMapping faultName="InstanceManagementException_Exception">
-                http://wso2.org/bps/management/wsdl/InstanceManagement/InstanceManagementPortType/getBPELInstanceVariableSize/Fault/instanceManagementException
+                http://wso2.org/bps/management/wsdl/InstanceManagement/InstanceManagementPortType/getInstanceViewVariableLength/Fault/instanceManagementException
             </faultActionMapping>
             <parameter name="AuthorizationAction" locked="true">
                 /permission/admin/manage/bpel/instances,/permission/admin/monitor/bpel

--- a/components/bpel/org.wso2.carbon.bpel/src/main/resources/META-INF/services.xml
+++ b/components/bpel/org.wso2.carbon.bpel/src/main/resources/META-INF/services.xml
@@ -248,6 +248,25 @@
         </parameter>
         <parameter name="useOriginalwsdl">true</parameter>
         <parameter name="modifyUserWSDLPortAddress">true</parameter>
+        <operation name="getBPELInstanceVariableSize" mep="http://www.w3.org/ns/wsdl/in-out"
+                   namespace="http://wso2.org/bps/management/wsdl/InstanceManagement">
+            <actionMapping>urn:getBPELInstanceVariableSize</actionMapping>
+            <outputActionMapping>
+                http://wso2.org/bps/management/wsdl/InstanceManagement/InstanceManagementPortType/getBPELInstanceVariableSizeResponse
+            </outputActionMapping>
+            <faultActionMapping faultName="instanceManagementException">
+                http://wso2.org/bps/management/wsdl/InstanceManagement/InstanceManagementPortType/getBPELInstanceVariableSize/Fault/instanceManagementException
+            </faultActionMapping>
+            <faultActionMapping faultName="InstanceManagementException">
+                http://wso2.org/bps/management/wsdl/InstanceManagement/InstanceManagementPortType/getBPELInstanceVariableSize/Fault/instanceManagementException
+            </faultActionMapping>
+            <faultActionMapping faultName="InstanceManagementException_Exception">
+                http://wso2.org/bps/management/wsdl/InstanceManagement/InstanceManagementPortType/getBPELInstanceVariableSize/Fault/instanceManagementException
+            </faultActionMapping>
+            <parameter name="AuthorizationAction" locked="true">
+                /permission/admin/manage/bpel/instances,/permission/admin/monitor/bpel
+            </parameter>
+        </operation>
         <operation name="getInstanceSummary" mep="http://www.w3.org/ns/wsdl/in-out"
                    namespace="http://wso2.org/bps/management/wsdl/InstanceManagement">
             <actionMapping>urn:getInstanceSummary</actionMapping>

--- a/components/bpel/org.wso2.carbon.bpel/src/main/resources/schemas/bps.xml
+++ b/components/bpel/org.wso2.carbon.bpel/src/main/resources/schemas/bps.xml
@@ -60,11 +60,6 @@
         <tns:property name="openjpa.FlushBeforeQueries" value="true"/>
     </tns:OpenJPAConfig>
 
-    <!--Set the maximum value size for a variable in a instance view in kilobytes,
-    higher sizes may slowdown the instance view rendering. Default size is 1000KB.
-    Please note that this only limits the displayed variable content size.-->
-    <!--<tns:InstanceViewVariableLength>1000</tns:InstanceViewVariableLength>-->
-
     <!-- Message exchange timeout. Default value is 120000ms -->
     <!--<tns:MexTimeOut value="120000"/>-->
 
@@ -143,5 +138,10 @@
         <!-- Interval between immediate retries when the transaction fails -->
         <!--<tns:ODESchedulerImmediateTransactionRetryInterval>1000</tns:ODESchedulerImmediateTransactionRetryInterval>-->
     <!--</tns:ODESchedulerConfiguration>-->
+
+    <!--Set the maximum value size for a variable in a instance view in kilobytes,
+    higher sizes may slowdown the instance view rendering. Default size is 1000KB.
+    Please note that this only limits the displayed variable content size.-->
+    <!--<tns:InstanceViewVariableLength>1000</tns:InstanceViewVariableLength>-->
 
 </tns:WSO2BPS>

--- a/components/bpel/org.wso2.carbon.bpel/src/main/resources/schemas/bps.xml
+++ b/components/bpel/org.wso2.carbon.bpel/src/main/resources/schemas/bps.xml
@@ -60,10 +60,10 @@
         <tns:property name="openjpa.FlushBeforeQueries" value="true"/>
     </tns:OpenJPAConfig>
 
-    <!--Set the maximum value size for a variable in a BPEL process in kilobytes,
+    <!--Set the maximum value size for a variable in a instance view in kilobytes,
     higher sizes may slowdown the instance view rendering. Default size is 1000KB.
     Please note that this only limits the displayed variable content size.-->
-    <!--<tns:BPELInstanceVariableSize>1000</tns:BPELInstanceVariableSize>-->
+    <!--<tns:InstanceViewVariableLength>1000</tns:InstanceViewVariableLength>-->
 
     <!-- Message exchange timeout. Default value is 120000ms -->
     <!--<tns:MexTimeOut value="120000"/>-->

--- a/components/bpel/org.wso2.carbon.bpel/src/main/resources/schemas/bps.xml
+++ b/components/bpel/org.wso2.carbon.bpel/src/main/resources/schemas/bps.xml
@@ -60,6 +60,11 @@
         <tns:property name="openjpa.FlushBeforeQueries" value="true"/>
     </tns:OpenJPAConfig>
 
+    <!--Set the maximum value size for a variable in a BPEL process in kilobytes,
+    higher sizes may slowdown the instance view rendering. Default size is 1000KB.
+    Please note that this only limits the displayed variable content size.-->
+    <!--<tns:BPELInstanceVariableSize>1000</tns:BPELInstanceVariableSize>-->
+
     <!-- Message exchange timeout. Default value is 120000ms -->
     <!--<tns:MexTimeOut value="120000"/>-->
 

--- a/components/bpel/org.wso2.carbon.bpel/src/main/resources/schemas/bps.xsd
+++ b/components/bpel/org.wso2.carbon.bpel/src/main/resources/schemas/bps.xsd
@@ -41,7 +41,7 @@
                          maxOccurs="1"/>
             <xsd:element name="OpenJPAConfig" type="tns:tOpenJPAConfig" minOccurs="0"
                          maxOccurs="1"/>
-            <xsd:element name="BPELInstanceVariableSize" type="xsd:int" minOccurs="0"
+            <xsd:element name="InstanceViewVariableLength" type="xsd:int" minOccurs="0"
                          maxOccurs="1"/>
             <xsd:element name="MexTimeOut" minOccurs="0" maxOccurs="1">
                 <xsd:complexType>

--- a/components/bpel/org.wso2.carbon.bpel/src/main/resources/schemas/bps.xsd
+++ b/components/bpel/org.wso2.carbon.bpel/src/main/resources/schemas/bps.xsd
@@ -41,6 +41,8 @@
                          maxOccurs="1"/>
             <xsd:element name="OpenJPAConfig" type="tns:tOpenJPAConfig" minOccurs="0"
                          maxOccurs="1"/>
+            <xsd:element name="BPELInstanceVariableSize" type="xsd:int" minOccurs="0"
+                         maxOccurs="1"/>
             <xsd:element name="MexTimeOut" minOccurs="0" maxOccurs="1">
                 <xsd:complexType>
                     <xsd:attribute name="value" type="xsd:int"/>

--- a/components/bpel/org.wso2.carbon.bpel/src/test/resources/conf/bps.xml
+++ b/components/bpel/org.wso2.carbon.bpel/src/test/resources/conf/bps.xml
@@ -61,11 +61,6 @@
         <tns:property name="openjpa.FlushBeforeQueries" value="false"/>
     </tns:OpenJPAConfig>
 
-    <!--Set the maximum value size for a variable in a instance view in kilobytes,
-    higher sizes may slowdown the instance view rendering. Default size is 1000KB.
-    Please note that this only limits the displayed variable content size.-->
-    <!--<tns:InstanceViewVariableLength>1000</tns:InstanceViewVariableLength>-->
-
     <!-- Message exchange timeout. Default value is 120000ms -->
     <tns:MexTimeOut value="120001"/>
 
@@ -111,5 +106,10 @@
     <!-- tns:UseDistributedLock>true</tns:UseDistributedLock> -->
     <!-- <tns:UseInstanceStateCache>true</tns:UseInstanceStateCache> -->
     <!-- <tns:PersistenceProvider>Hibernate<tns:PersistenceProvider> --> 
+
+    <!--Set the maximum value size for a variable in a instance view in kilobytes,
+    higher sizes may slowdown the instance view rendering. Default size is 1000KB.
+    Please note that this only limits the displayed variable content size.-->
+    <!--<tns:InstanceViewVariableLength>1000</tns:InstanceViewVariableLength>-->
 
 </tns:WSO2BPS>

--- a/components/bpel/org.wso2.carbon.bpel/src/test/resources/conf/bps.xml
+++ b/components/bpel/org.wso2.carbon.bpel/src/test/resources/conf/bps.xml
@@ -61,10 +61,10 @@
         <tns:property name="openjpa.FlushBeforeQueries" value="false"/>
     </tns:OpenJPAConfig>
 
-    <!--Set the maximum value size for a variable in a BPEL process in kilobytes,
+    <!--Set the maximum value size for a variable in a instance view in kilobytes,
     higher sizes may slowdown the instance view rendering. Default size is 1000KB.
     Please note that this only limits the displayed variable content size.-->
-    <!--<tns:BPELInstanceVariableSize>1000</tns:BPELInstanceVariableSize>-->
+    <!--<tns:InstanceViewVariableLength>1000</tns:InstanceViewVariableLength>-->
 
     <!-- Message exchange timeout. Default value is 120000ms -->
     <tns:MexTimeOut value="120001"/>

--- a/components/bpel/org.wso2.carbon.bpel/src/test/resources/conf/bps.xml
+++ b/components/bpel/org.wso2.carbon.bpel/src/test/resources/conf/bps.xml
@@ -61,6 +61,11 @@
         <tns:property name="openjpa.FlushBeforeQueries" value="false"/>
     </tns:OpenJPAConfig>
 
+    <!--Set the maximum value size for a variable in a BPEL process in kilobytes,
+    higher sizes may slowdown the instance view rendering. Default size is 1000KB.
+    Please note that this only limits the displayed variable content size.-->
+    <!--<tns:BPELInstanceVariableSize>1000</tns:BPELInstanceVariableSize>-->
+
     <!-- Message exchange timeout. Default value is 120000ms -->
     <tns:MexTimeOut value="120001"/>
 

--- a/features/bpel/org.wso2.carbon.bpel.server.feature/resources/conf/bps.xml
+++ b/features/bpel/org.wso2.carbon.bpel.server.feature/resources/conf/bps.xml
@@ -59,11 +59,6 @@
         <tns:property name="openjpa.FlushBeforeQueries" value="true"/>
     </tns:OpenJPAConfig>
 
-    <!--Set the maximum value size for a variable in a instance view in kilobytes,
-    higher sizes may slowdown the instance view rendering. Default size is 1000KB.
-    Please note that this only limits the displayed variable content size.-->
-    <!--<tns:InstanceViewVariableLength>1000</tns:InstanceViewVariableLength>-->
-
     <!-- Message exchange timeout. Default value is 120000ms -->
     <!--<tns:MexTimeOut value="120000"/>-->
 
@@ -139,5 +134,10 @@
 
     <!-- End of Simple Scheduler related configuration -->
     <!--</tns:ODESchedulerConfiguration>-->
+
+    <!--Set the maximum value size for a variable in a instance view in kilobytes,
+    higher sizes may slowdown the instance view rendering. Default size is 1000KB.
+    Please note that this only limits the displayed variable content size.-->
+    <!--<tns:InstanceViewVariableLength>1000</tns:InstanceViewVariableLength>-->
 
 </tns:WSO2BPS>

--- a/features/bpel/org.wso2.carbon.bpel.server.feature/resources/conf/bps.xml
+++ b/features/bpel/org.wso2.carbon.bpel.server.feature/resources/conf/bps.xml
@@ -59,6 +59,11 @@
         <tns:property name="openjpa.FlushBeforeQueries" value="true"/>
     </tns:OpenJPAConfig>
 
+    <!--Set the maximum value size for a variable in a BPEL process in kilobytes,
+    higher sizes may slowdown the instance view rendering. Default size is 1000KB.
+    Please note that this only limits the displayed variable content size.-->
+    <!--<tns:BPELInstanceVariableSize>1000</tns:BPELInstanceVariableSize>-->
+
     <!-- Message exchange timeout. Default value is 120000ms -->
     <!--<tns:MexTimeOut value="120000"/>-->
 

--- a/features/bpel/org.wso2.carbon.bpel.server.feature/resources/conf/bps.xml
+++ b/features/bpel/org.wso2.carbon.bpel.server.feature/resources/conf/bps.xml
@@ -59,10 +59,10 @@
         <tns:property name="openjpa.FlushBeforeQueries" value="true"/>
     </tns:OpenJPAConfig>
 
-    <!--Set the maximum value size for a variable in a BPEL process in kilobytes,
+    <!--Set the maximum value size for a variable in a instance view in kilobytes,
     higher sizes may slowdown the instance view rendering. Default size is 1000KB.
     Please note that this only limits the displayed variable content size.-->
-    <!--<tns:BPELInstanceVariableSize>1000</tns:BPELInstanceVariableSize>-->
+    <!--<tns:InstanceViewVariableLength>1000</tns:InstanceViewVariableLength>-->
 
     <!-- Message exchange timeout. Default value is 120000ms -->
     <!--<tns:MexTimeOut value="120000"/>-->

--- a/service-stubs/bpel/org.wso2.carbon.bpel.skeleton/src/main/resources/bps_management.xsd
+++ b/service-stubs/bpel/org.wso2.carbon.bpel.skeleton/src/main/resources/bps_management.xsd
@@ -30,6 +30,7 @@
         </xsd:complexType>
     </xsd:element>
 
+    <xsd:element name="BPELInstanceVariableSize" type="xsd:int"/>
     <!--The following elements are added to describe process contents-->
     <xsd:element name="getProcessDeployDetails" type="xsd:QName"/>
     <xsd:element name="ProcessDeployDetailsList">

--- a/service-stubs/bpel/org.wso2.carbon.bpel.skeleton/src/main/resources/bps_management.xsd
+++ b/service-stubs/bpel/org.wso2.carbon.bpel.skeleton/src/main/resources/bps_management.xsd
@@ -30,7 +30,7 @@
         </xsd:complexType>
     </xsd:element>
 
-    <xsd:element name="BPELInstanceVariableSize" type="xsd:int"/>
+    <xsd:element name="InstanceViewVariableLength" type="xsd:int"/>
     <!--The following elements are added to describe process contents-->
     <xsd:element name="getProcessDeployDetails" type="xsd:QName"/>
     <xsd:element name="ProcessDeployDetailsList">

--- a/service-stubs/bpel/org.wso2.carbon.bpel.skeleton/src/main/resources/instance_mgt.wsdl
+++ b/service-stubs/bpel/org.wso2.carbon.bpel.skeleton/src/main/resources/instance_mgt.wsdl
@@ -29,6 +29,10 @@
         </xsd:schema>
     </types>
 
+    <message name="getBPELInstanceVariableSizeRequest"/>
+    <message name="getBPELInstanceVariableSizeResponse">
+        <part name="part" element="ns:BPELInstanceVariableSize"/>
+    </message>
     <message name="getPaginatedInstanceListRequest">
         <part name="part" element="ns:getPaginatedInstanceListInput"/>
     </message>
@@ -126,6 +130,11 @@
     </message>
 
     <portType name="InstanceManagementPortType">
+        <operation name="getBPELInstanceVariableSize">
+            <input message="tns:getBPELInstanceVariableSizeRequest"/>
+            <output message="tns:getBPELInstanceVariableSizeResponse"/>
+            <fault name="instanceManagementException" message="tns:instanceManagementException" />
+        </operation>
         <operation name="getPaginatedInstanceList">
             <input message="tns:getPaginatedInstanceListRequest"/>
             <output message="tns:getPaginatedInstanceListResponse"/>
@@ -201,6 +210,18 @@
     </portType>
     <binding name="InstanceManagementSOAPBinding" type="tns:InstanceManagementPortType">
         <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <operation name="getBPELInstanceVariableSize">
+            <soap:operation soapAction="urn:getBPELInstanceVariableSize"/>
+            <input>
+                <soap:body use="literal"/>
+            </input>
+            <output>
+                <soap:body use="literal"/>
+            </output>
+            <fault name="instanceManagementException">
+                <soap:fault name="instanceManagementException" use="literal"/>
+            </fault>
+        </operation>
         <operation name="getPaginatedInstanceList">
             <soap:operation soapAction="urn:getPaginatedInstanceList"/>
             <input>

--- a/service-stubs/bpel/org.wso2.carbon.bpel.skeleton/src/main/resources/instance_mgt.wsdl
+++ b/service-stubs/bpel/org.wso2.carbon.bpel.skeleton/src/main/resources/instance_mgt.wsdl
@@ -29,9 +29,9 @@
         </xsd:schema>
     </types>
 
-    <message name="getBPELInstanceVariableSizeRequest"/>
-    <message name="getBPELInstanceVariableSizeResponse">
-        <part name="part" element="ns:BPELInstanceVariableSize"/>
+    <message name="getInstanceViewVariableLengthRequest"/>
+    <message name="getInstanceViewVariableLengthResponse">
+        <part name="part" element="ns:InstanceViewVariableLength"/>
     </message>
     <message name="getPaginatedInstanceListRequest">
         <part name="part" element="ns:getPaginatedInstanceListInput"/>
@@ -130,9 +130,9 @@
     </message>
 
     <portType name="InstanceManagementPortType">
-        <operation name="getBPELInstanceVariableSize">
-            <input message="tns:getBPELInstanceVariableSizeRequest"/>
-            <output message="tns:getBPELInstanceVariableSizeResponse"/>
+        <operation name="getInstanceViewVariableLength">
+            <input message="tns:getInstanceViewVariableLengthRequest"/>
+            <output message="tns:getInstanceViewVariableLengthResponse"/>
             <fault name="instanceManagementException" message="tns:instanceManagementException" />
         </operation>
         <operation name="getPaginatedInstanceList">
@@ -210,8 +210,8 @@
     </portType>
     <binding name="InstanceManagementSOAPBinding" type="tns:InstanceManagementPortType">
         <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
-        <operation name="getBPELInstanceVariableSize">
-            <soap:operation soapAction="urn:getBPELInstanceVariableSize"/>
+        <operation name="getInstanceViewVariableLength">
+            <soap:operation soapAction="urn:getInstanceViewVariableLength"/>
             <input>
                 <soap:body use="literal"/>
             </input>

--- a/service-stubs/bpel/org.wso2.carbon.bpel.stub/src/main/resources/bps_management.xsd
+++ b/service-stubs/bpel/org.wso2.carbon.bpel.stub/src/main/resources/bps_management.xsd
@@ -30,6 +30,7 @@
         </xsd:complexType>
     </xsd:element>
 
+    <xsd:element name="BPELInstanceVariableSize" type="xsd:int"/>
     <!--The following elements are added to describe process contents-->
     <xsd:element name="getProcessDeployDetails" type="xsd:QName"/>
     <xsd:element name="ProcessDeployDetailsList">

--- a/service-stubs/bpel/org.wso2.carbon.bpel.stub/src/main/resources/bps_management.xsd
+++ b/service-stubs/bpel/org.wso2.carbon.bpel.stub/src/main/resources/bps_management.xsd
@@ -30,7 +30,7 @@
         </xsd:complexType>
     </xsd:element>
 
-    <xsd:element name="BPELInstanceVariableSize" type="xsd:int"/>
+    <xsd:element name="InstanceViewVariableLength" type="xsd:int"/>
     <!--The following elements are added to describe process contents-->
     <xsd:element name="getProcessDeployDetails" type="xsd:QName"/>
     <xsd:element name="ProcessDeployDetailsList">

--- a/service-stubs/bpel/org.wso2.carbon.bpel.stub/src/main/resources/instance_mgt.wsdl
+++ b/service-stubs/bpel/org.wso2.carbon.bpel.stub/src/main/resources/instance_mgt.wsdl
@@ -29,6 +29,10 @@
         </xsd:schema>
     </types>
 
+    <message name="getBPELInstanceVariableSizeRequest"/>
+    <message name="getBPELInstanceVariableSizeResponse">
+        <part name="part" element="ns:BPELInstanceVariableSize"/>
+    </message>
     <message name="getPaginatedInstanceListRequest">
         <part name="part" element="ns:getPaginatedInstanceListInput"/>
     </message>
@@ -126,6 +130,11 @@
     </message>
 
     <portType name="InstanceManagementPortType">
+        <operation name="getBPELInstanceVariableSize">
+            <input message="tns:getBPELInstanceVariableSizeRequest"/>
+            <output message="tns:getBPELInstanceVariableSizeResponse"/>
+            <fault name="instanceManagementException" message="tns:instanceManagementException" />
+        </operation>
         <operation name="getPaginatedInstanceList">
             <input message="tns:getPaginatedInstanceListRequest"/>
             <output message="tns:getPaginatedInstanceListResponse"/>
@@ -201,6 +210,18 @@
     </portType>
     <binding name="InstanceManagementSOAPBinding" type="tns:InstanceManagementPortType">
         <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <operation name="getBPELInstanceVariableSize">
+            <soap:operation soapAction="urn:getBPELInstanceVariableSize"/>
+            <input>
+                <soap:body use="literal"/>
+            </input>
+            <output>
+                <soap:body use="literal"/>
+            </output>
+            <fault name="instanceManagementException">
+                <soap:fault name="instanceManagementException" use="literal"/>
+            </fault>
+        </operation>
         <operation name="getPaginatedInstanceList">
             <soap:operation soapAction="urn:getPaginatedInstanceList"/>
             <input>

--- a/service-stubs/bpel/org.wso2.carbon.bpel.stub/src/main/resources/instance_mgt.wsdl
+++ b/service-stubs/bpel/org.wso2.carbon.bpel.stub/src/main/resources/instance_mgt.wsdl
@@ -29,9 +29,9 @@
         </xsd:schema>
     </types>
 
-    <message name="getBPELInstanceVariableSizeRequest"/>
-    <message name="getBPELInstanceVariableSizeResponse">
-        <part name="part" element="ns:BPELInstanceVariableSize"/>
+    <message name="getInstanceViewVariableLengthRequest"/>
+    <message name="getInstanceViewVariableLengthResponse">
+        <part name="part" element="ns:InstanceViewVariableLength"/>
     </message>
     <message name="getPaginatedInstanceListRequest">
         <part name="part" element="ns:getPaginatedInstanceListInput"/>
@@ -130,9 +130,9 @@
     </message>
 
     <portType name="InstanceManagementPortType">
-        <operation name="getBPELInstanceVariableSize">
-            <input message="tns:getBPELInstanceVariableSizeRequest"/>
-            <output message="tns:getBPELInstanceVariableSizeResponse"/>
+        <operation name="getInstanceViewVariableLength">
+            <input message="tns:getInstanceViewVariableLengthRequest"/>
+            <output message="tns:getInstanceViewVariableLengthResponse"/>
             <fault name="instanceManagementException" message="tns:instanceManagementException" />
         </operation>
         <operation name="getPaginatedInstanceList">
@@ -210,8 +210,8 @@
     </portType>
     <binding name="InstanceManagementSOAPBinding" type="tns:InstanceManagementPortType">
         <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
-        <operation name="getBPELInstanceVariableSize">
-            <soap:operation soapAction="urn:getBPELInstanceVariableSize"/>
+        <operation name="getInstanceViewVariableLength">
+            <soap:operation soapAction="urn:getInstanceViewVariableLength"/>
             <input>
                 <soap:body use="literal"/>
             </input>


### PR DESCRIPTION
Adding new configuration item to max BPEL instance variable size forUI, truncating variable view in instance view. for issue - https://wso2.org/jira/browse/BPS-597