### PR TITLE
Limiting number of bpel instances that can be deleted in single request

### DIFF
--- a/components/bpel/org.wso2.carbon.bpel.ui/src/main/java/org/wso2/carbon/bpel/ui/clients/InstanceManagementServiceClient.java
+++ b/components/bpel/org.wso2.carbon.bpel.ui/src/main/java/org/wso2/carbon/bpel/ui/clients/InstanceManagementServiceClient.java
@@ -154,10 +154,10 @@ public class InstanceManagementServiceClient {
         }
     }
 
-    public void deleteInstances(String filter, boolean deleteMessageExchanges)
+    public int deleteInstances(String filter, boolean deleteMessageExchanges)
             throws RemoteException, InstanceManagementException {
         try {
-            stub.deleteInstances(filter, deleteMessageExchanges);
+            return stub.deleteInstances(filter, deleteMessageExchanges);
         } catch (RemoteException re) {
             log.error("deleteInstances operation failed.", re);
             throw re;

--- a/components/bpel/org.wso2.carbon.bpel.ui/src/main/resources/org/wso2/carbon/bpel/ui/i18n/Resources.properties
+++ b/components/bpel/org.wso2.carbon.bpel.ui/src/main/resources/org/wso2/carbon/bpel/ui/i18n/Resources.properties
@@ -202,6 +202,7 @@ clear=Clear
 error.occured.while.getting.instances=Error occured while getting instances.
 error.occured.while.getting.process.list=Error occured while getting process list.
 show.instances=Show Instances
+bpel.instance.delete.done=instances successfully deleted! If there are remaining instances, please press delete again.
 instaces.created=Instances Created
 bpel.package.uploaded.successfully=BPEL Package Uploaded Successfully!
 file.uploading.failed=File uploading failed. Please refer logs for more details.

--- a/components/bpel/org.wso2.carbon.bpel.ui/src/main/resources/web/bpel/list_instances.jsp
+++ b/components/bpel/org.wso2.carbon.bpel.ui/src/main/resources/web/bpel/list_instances.jsp
@@ -41,7 +41,7 @@
 
 <jsp:useBean id="instanceFilter" scope="session" class="org.wso2.carbon.bpel.ui.InstanceFilter"/>
 <jsp:setProperty name="instanceFilter" property="*"/>
-
+<jsp:include page="../dialog/display_messages.jsp"/>
 
 <%
     response.setHeader("Cache-Control",
@@ -229,12 +229,20 @@
 
 } else if (operation.equals("deleteInstances")) {
     try {
+        int deletedCount = 0;
         retryActivityFlag = false;
         if (deleteMex == null) {
-            client.deleteInstances(instanceListFilter, false);
+            deletedCount = client.deleteInstances(instanceListFilter, false);
         } else {
-            client.deleteInstances(instanceListFilter, true);
+            deletedCount = client.deleteInstances(instanceListFilter, true);
         }
+%>
+            <fmt:bundle basename="org.wso2.carbon.bpel.ui.i18n.Resources">
+                <script type="application/javascript">
+                    CARBON.showInfoDialog(<% out.print(deletedCount); %> + ' ' + '<fmt:message key="bpel.instance.delete.done" />');
+                </script>
+            </fmt:bundle>
+<%
     } catch (Exception e) {
         response.setStatus(HttpStatus.SC_INTERNAL_SERVER_ERROR);
         CarbonUIMessage uiMsg = new CarbonUIMessage(CarbonUIMessage.ERROR, e.getMessage(), e);

--- a/components/bpel/org.wso2.carbon.bpel/src/main/java/org/wso2/carbon/bpel/core/BPELConstants.java
+++ b/components/bpel/org.wso2.carbon.bpel/src/main/java/org/wso2/carbon/bpel/core/BPELConstants.java
@@ -265,6 +265,8 @@ public final class BPELConstants {
 
     public static final int DEFAULT_INSTANCE_VIEW_VARIABLE_LENGTH = 1000;
 
+    public static final int DEFAULT_INSTANCE_DELETION_LIMIT = 1000;
+
     /*  added to set updated properties of a package*/
     public static final String BPEL_INSTANCE_CLEANUP_FAILURE =  "bpel.instance.cleanup.failure: ";
     public static final String BPEL_INSTANCE_CLEANUP_SUCCESS =  "bpel.instance.cleanup.success:";

--- a/components/bpel/org.wso2.carbon.bpel/src/main/java/org/wso2/carbon/bpel/core/ode/integration/config/BPELServerConfiguration.java
+++ b/components/bpel/org.wso2.carbon.bpel/src/main/java/org/wso2/carbon/bpel/core/ode/integration/config/BPELServerConfiguration.java
@@ -121,6 +121,7 @@ public class BPELServerConfiguration {
     private String password = null;
     private int maxPoolSize = 100;
     private int minPoolSize = 5;
+    private int bpelInstanceDeletionLimit = BPELConstants.DEFAULT_INSTANCE_DELETION_LIMIT;
 
 
     //SimpleScheduler Configuration
@@ -282,6 +283,15 @@ public class BPELServerConfiguration {
         return jobs;
     }
 
+    /**
+     * Returns the maximum number of instances that can be deleted in a delete instance request as defined in bps.xml.
+     * Default is 1000.
+     * @return bpelInstanceDeletionLimit - maximum number of instance that can delete in single request
+     */
+    public int getBpelInstanceDeletionLimit() {
+        return bpelInstanceDeletionLimit;
+    }
+
     public static void processACleanup(Set<ProcessConf.CLEANUP_CATEGORY> categories,
                                        List<TCleanup.Category.Enum> categoryList) {
         if (categoryList.isEmpty()) {
@@ -440,6 +450,14 @@ public class BPELServerConfiguration {
         populateNodeId();
         populateODESchedulerConfiguration();
         populateInstanceViewVariableLength();
+        populateBpelInstanceDeletionLimit();
+    }
+
+    private void populateBpelInstanceDeletionLimit() {
+        TBpelUI bpelUI = bpsConfigDocument.getWSO2BPS().getBpelUI();
+        if (bpelUI != null && bpelUI.isSetBpelInstanceDeletionLimit()) {
+            this.bpelInstanceDeletionLimit = bpelUI.getBpelInstanceDeletionLimit();
+        }
     }
 
     private void populateSyncWithRegistry() {
@@ -664,10 +682,10 @@ public class BPELServerConfiguration {
     }
 
     private void populateInstanceViewVariableLength() {
-        if(bpsConfigDocument.getWSO2BPS().isSetInstanceViewVariableLength()) {
-            this.instanceViewVariableLength = bpsConfigDocument.getWSO2BPS().getInstanceViewVariableLength();
+        TBpelUI bpelUI = bpsConfigDocument.getWSO2BPS().getBpelUI();
+        if (bpelUI != null && bpelUI.isSetInstanceViewVariableLength()) {
+            this.instanceViewVariableLength = bpelUI.getInstanceViewVariableLength();
         }
-
     }
 
     public String getPersistenceProvider() {

--- a/components/bpel/org.wso2.carbon.bpel/src/main/resources/schemas/bps.xml
+++ b/components/bpel/org.wso2.carbon.bpel/src/main/resources/schemas/bps.xml
@@ -139,9 +139,16 @@
         <!--<tns:ODESchedulerImmediateTransactionRetryInterval>1000</tns:ODESchedulerImmediateTransactionRetryInterval>-->
     <!--</tns:ODESchedulerConfiguration>-->
 
-    <!--Set the maximum value size for a variable in a instance view in kilobytes,
-    higher sizes may slowdown the instance view rendering. Default size is 1000KB.
-    Please note that this only limits the displayed variable content size.-->
-    <!--<tns:InstanceViewVariableLength>1000</tns:InstanceViewVariableLength>-->
+    <!--Configurations for BPEL UI-->
+    <tns:BpelUI>
+        <!--Set the maximum value size for a variable in a instance view in kilobytes,-->
+        <!--higher sizes may slowdown the instance view rendering. Default size is 1000KB.-->
+        <!--Please note that this only limits the displayed variable content size.-->
+        <!--<tns:InstanceViewVariableLength>1000</tns:InstanceViewVariableLength>-->
+
+        <!--This property specify the maximum number of BPEL process instances that can be deleted in a single delete instance-->
+        <!--request. Default value is 1000. Increase this with caution. It may result in various timeout exceptions.-->
+        <!--<tns:BpelInstanceDeletionLimit>1000</tns:BpelInstanceDeletionLimit>-->
+    </tns:BpelUI>
 
 </tns:WSO2BPS>

--- a/components/bpel/org.wso2.carbon.bpel/src/main/resources/schemas/bps.xsd
+++ b/components/bpel/org.wso2.carbon.bpel/src/main/resources/schemas/bps.xsd
@@ -41,8 +41,6 @@
                          maxOccurs="1"/>
             <xsd:element name="OpenJPAConfig" type="tns:tOpenJPAConfig" minOccurs="0"
                          maxOccurs="1"/>
-            <xsd:element name="InstanceViewVariableLength" type="xsd:int" minOccurs="0"
-                         maxOccurs="1"/>
             <xsd:element name="MexTimeOut" minOccurs="0" maxOccurs="1">
                 <xsd:complexType>
                     <xsd:attribute name="value" type="xsd:int"/>
@@ -68,7 +66,7 @@
             <xsd:element name="PersistenceProvider" type="xsd:string" minOccurs="0" maxOccurs="1"></xsd:element>
             <xsd:element name="NodeId" type="xsd:string" minOccurs="0" maxOccurs="1"></xsd:element>
             <xsd:element name="ODESchedulerConfiguration" type="tns:simpleSchedulerConfig" minOccurs="0" maxOccurs="1"/>
-
+            <xsd:element name="BpelUI" type="tns:tBpelUI" maxOccurs="1" minOccurs="0"/>
         </xsd:sequence>
     </xsd:complexType>
 
@@ -272,6 +270,14 @@
             <xsd:element name="ODESchedulerWarningDelay" type="xsd:long" />
             <xsd:element name="ODESchedulerImmediateTransactionRetryLimit" type="xsd:int" />
             <xsd:element name="ODESchedulerImmediateTransactionRetryInterval" type="xsd:long" />
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="tBpelUI">
+        <xsd:sequence>
+            <xsd:element name="BpelInstanceDeletionLimit" type="xsd:int" maxOccurs="1"
+                         minOccurs="0"/>
+            <xsd:element name="InstanceViewVariableLength" type="xsd:int" minOccurs="0"
+                         maxOccurs="1"/>
         </xsd:sequence>
     </xsd:complexType>
 </xsd:schema>

--- a/components/bpel/org.wso2.carbon.bpel/src/test/resources/conf/bps.xml
+++ b/components/bpel/org.wso2.carbon.bpel/src/test/resources/conf/bps.xml
@@ -107,9 +107,16 @@
     <!-- <tns:UseInstanceStateCache>true</tns:UseInstanceStateCache> -->
     <!-- <tns:PersistenceProvider>Hibernate<tns:PersistenceProvider> --> 
 
-    <!--Set the maximum value size for a variable in a instance view in kilobytes,
-    higher sizes may slowdown the instance view rendering. Default size is 1000KB.
-    Please note that this only limits the displayed variable content size.-->
-    <!--<tns:InstanceViewVariableLength>1000</tns:InstanceViewVariableLength>-->
+    <!--Configurations for BPEL UI-->
+    <tns:BpelUI>
+        <!--Set the maximum value size for a variable in a instance view in kilobytes,-->
+        <!--higher sizes may slowdown the instance view rendering. Default size is 1000KB.-->
+        <!--Please note that this only limits the displayed variable content size.-->
+        <!--<tns:InstanceViewVariableLength>1000</tns:InstanceViewVariableLength>-->
+
+        <!--This property specify the maximum number of BPEL process instances that can be deleted in a single delete instance-->
+        <!--request. Default value is 1000. Increase this with caution. It may result in various timeout exceptions.-->
+        <!--<tns:BpelInstanceDeletionLimit>1000</tns:BpelInstanceDeletionLimit>-->
+    </tns:BpelUI>
 
 </tns:WSO2BPS>

--- a/features/bpel/org.wso2.carbon.bpel.server.feature/resources/conf/bps.xml
+++ b/features/bpel/org.wso2.carbon.bpel.server.feature/resources/conf/bps.xml
@@ -135,9 +135,16 @@
     <!-- End of Simple Scheduler related configuration -->
     <!--</tns:ODESchedulerConfiguration>-->
 
-    <!--Set the maximum value size for a variable in a instance view in kilobytes,
-    higher sizes may slowdown the instance view rendering. Default size is 1000KB.
-    Please note that this only limits the displayed variable content size.-->
-    <!--<tns:InstanceViewVariableLength>1000</tns:InstanceViewVariableLength>-->
+    <!--Configurations for BPEL UI-->
+    <tns:BpelUI>
+        <!--Set the maximum value size for a variable in a instance view in kilobytes,-->
+        <!--higher sizes may slowdown the instance view rendering. Default size is 1000KB.-->
+        <!--Please note that this only limits the displayed variable content size.-->
+        <!--<tns:InstanceViewVariableLength>1000</tns:InstanceViewVariableLength>-->
+
+        <!--This property specify the maximum number of BPEL process instances that can be deleted in a single delete instance-->
+        <!--request. Default value is 1000. Increase this with caution. It may result in various timeout exceptions.-->
+        <!--<tns:BpelInstanceDeletionLimit>1000</tns:BpelInstanceDeletionLimit>-->
+    </tns:BpelUI>
 
 </tns:WSO2BPS>


### PR DESCRIPTION
Limiting number of bpel instances that can be deleted in single request, to a configuratin value. Issue - https://wso2.org/jira/browse/BPS-228