### PR TITLE
Fixing UI defect of humantask-explorer login name

### DIFF
--- a/components/humantask/humantask-explorer-web/src/web/css/style.css
+++ b/components/humantask/humantask-explorer-web/src/web/css/style.css
@@ -356,7 +356,6 @@ header {
 }
 
 .login-wrapper {
-    width: 200px;
     float: right;
     background-color: #272727;
     color: #fff;


### PR DESCRIPTION
In humantask- explorer if the user name is too lengthy, the logout link is not displayed. 