### PR TITLE
changing Exception names to avoid inappropriate exception class names

### DIFF
--- a/service-stubs/bpmn/org.wso2.carbon.bpmn.stub/src/main/resources/BPMNDeploymentService.wsdl
+++ b/service-stubs/bpmn/org.wso2.carbon.bpmn.stub/src/main/resources/BPMNDeploymentService.wsdl
@@ -26,7 +26,7 @@
         <xs:schema xmlns:ax24="http://model.mgt.core.bpmn.carbon.wso2.org/xsd" xmlns:ax22="http://core.bpmn.carbon.wso2.org/xsd" attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://services.mgt.core.bpmn.carbon.wso2.org">
             <xs:import namespace="http://core.bpmn.carbon.wso2.org/xsd"/>
             <xs:import namespace="http://model.mgt.core.bpmn.carbon.wso2.org/xsd"/>
-            <xs:element name="BPMNDeploymentServiceBPSException">
+            <xs:element name="BPMNDeploymentServiceBPSFault">
                 <xs:complexType>
                     <xs:sequence>
                         <xs:element minOccurs="0" name="BPSException" nillable="true" type="ax21:BPSException"/>
@@ -101,7 +101,7 @@
         <wsdl:part name="parameters" element="ns:getDeployedProcessesResponse"/>
     </wsdl:message>
     <wsdl:message name="BPMNDeploymentServiceBPSException">
-        <wsdl:part name="parameters" element="ns:BPMNDeploymentServiceBPSException"/>
+        <wsdl:part name="parameters" element="ns:BPMNDeploymentServiceBPSFault"/>
     </wsdl:message>
     <wsdl:message name="getProcessModelRequest">
         <wsdl:part name="parameters" element="ns:getProcessModel"/>

--- a/service-stubs/bpmn/org.wso2.carbon.bpmn.stub/src/main/resources/BPMNHumanTaskService.wsdl
+++ b/service-stubs/bpmn/org.wso2.carbon.bpmn.stub/src/main/resources/BPMNHumanTaskService.wsdl
@@ -18,7 +18,7 @@
         <xs:schema xmlns:ax24="http://model.mgt.core.bpmn.carbon.wso2.org/xsd" xmlns:ax22="http://core.bpmn.carbon.wso2.org/xsd" attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://services.mgt.core.bpmn.carbon.wso2.org">
             <xs:import namespace="http://core.bpmn.carbon.wso2.org/xsd"/>
             <xs:import namespace="http://model.mgt.core.bpmn.carbon.wso2.org/xsd"/>
-            <xs:element name="BPMNHumanTasksServiceBPSException">
+            <xs:element name="BPMNHumanTasksServiceBPSFault">
                 <xs:complexType>
                     <xs:sequence>
                         <xs:element minOccurs="0" name="BPSException" nillable="true" type="ax21:BPSException"/>
@@ -52,7 +52,7 @@
         <wsdl:part name="parameters" element="ns:completeTask"/>
     </wsdl:message>
     <wsdl:message name="BPMNHumanTasksServiceBPSException">
-        <wsdl:part name="parameters" element="ns:BPMNHumanTasksServiceBPSException"/>
+        <wsdl:part name="parameters" element="ns:BPMNHumanTasksServiceBPSFault"/>
     </wsdl:message>
     <wsdl:message name="getTasksOfUserRequest">
         <wsdl:part name="parameters" element="ns:getTasksOfUser"/>

--- a/service-stubs/bpmn/org.wso2.carbon.bpmn.stub/src/main/resources/BPMNInstanceService.wsdl
+++ b/service-stubs/bpmn/org.wso2.carbon.bpmn.stub/src/main/resources/BPMNInstanceService.wsdl
@@ -26,7 +26,7 @@
         <xs:schema xmlns:ax224="http://core.bpmn.carbon.wso2.org/xsd" xmlns:ax226="http://model.mgt.core.bpmn.carbon.wso2.org/xsd" attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://services.mgt.core.bpmn.carbon.wso2.org">
             <xs:import namespace="http://core.bpmn.carbon.wso2.org/xsd"></xs:import>
             <xs:import namespace="http://model.mgt.core.bpmn.carbon.wso2.org/xsd"></xs:import>
-            <xs:element name="BPMNInstanceServiceBPSException">
+            <xs:element name="BPMNInstanceServiceBPSFault">
                 <xs:complexType>
                     <xs:sequence>
                         <xs:element minOccurs="0" name="BPSException" nillable="true" type="ax223:BPSException"></xs:element>
@@ -112,7 +112,7 @@
         <wsdl:part name="parameters" element="ns:suspendProcessInstance"></wsdl:part>
     </wsdl:message>
     <wsdl:message name="BPMNInstanceServiceBPSException">
-        <wsdl:part name="parameters" element="ns:BPMNInstanceServiceBPSException"></wsdl:part>
+        <wsdl:part name="parameters" element="ns:BPMNInstanceServiceBPSFault"></wsdl:part>
     </wsdl:message>
     <wsdl:message name="getInstanceCountRequest">
         <wsdl:part name="parameters" element="ns:getInstanceCount"></wsdl:part>


### PR DESCRIPTION
changing Exception names to avoid inappropriate exception class names. Issue - https://wso2.org/jira/browse/BPS-577