### PR TITLE
Fixing bpmn undeploy issue in firefox

### DIFF
--- a/components/bpmn/org.wso2.carbon.bpmn.ui/src/main/resources/web/bpmn/package_dashboard.jsp
+++ b/components/bpmn/org.wso2.carbon.bpmn.ui/src/main/resources/web/bpmn/package_dashboard.jsp
@@ -64,7 +64,7 @@
             </thead>
             <tbody>
             <tr>
-                <td><a href="javascript:deletePackage();">
+                <td><a href="#" onclick="deletePackage();">
                     <img src="images/undeploy.gif">&nbsp;<fmt:message key="bpmn.package.undeploy"/></a></td>
             </tr>
             </tbody>


### PR DESCRIPTION
When having <href=javascript:deletePackage();"/> in firefox (windows environment) the value returned from the function is set as a string and is rendered. This is fixed by having the javascript function 'onclick' 