### PR TITLE
Send REST Task input payload as UTF-8

### DIFF
--- a/components/bpmn/org.wso2.carbon.bpmn.extensions/src/main/java/org/wso2/carbon/bpmn/extensions/rest/RESTInvoker.java
+++ b/components/bpmn/org.wso2.carbon.bpmn.extensions/src/main/java/org/wso2/carbon/bpmn/extensions/rest/RESTInvoker.java
@@ -251,7 +251,7 @@ public class RESTInvoker {
         String output;
         try {
             httpPost = new HttpPost(uri);
-            httpPost.setEntity(new StringEntity(payload));
+            httpPost.setEntity(new StringEntity(payload, StandardCharsets.UTF_8));
             processHeaderList(httpPost, jsonHeaders);
             response = sendReceiveRequest(httpPost, username, password);
             output = IOUtils.toString(response.getEntity().getContent());
@@ -296,7 +296,7 @@ public class RESTInvoker {
         String output;
         try {
             httpPut = new HttpPut(uri);
-            httpPut.setEntity(new StringEntity(payload));
+            httpPut.setEntity(new StringEntity(payload, StandardCharsets.UTF_8));
             processHeaderList(httpPut, jsonHeaders);
             response = sendReceiveRequest(httpPut, username, password);
             output = IOUtils.toString(response.getEntity().getContent());


### PR DESCRIPTION
Fix for https://github.com/wso2/product-ei/issues/924 
Constructor of StringEntity which used in REST Task PUT and POST actions sets charset to HTTP.DEF_CONTENT_CHARSET i.e. "ISO-8859-1", which is not very useful. Set charset to UTF-8 instead.