### PR TITLE
[EI-924]Fix unicode character issue in bpmn RESTTask input

### DIFF
--- a/components/bpmn/org.wso2.carbon.bpmn.extensions/src/main/java/org/wso2/carbon/bpmn/extensions/rest/RESTInvoker.java
+++ b/components/bpmn/org.wso2.carbon.bpmn.extensions/src/main/java/org/wso2/carbon/bpmn/extensions/rest/RESTInvoker.java
@@ -15,6 +15,7 @@
  */
 package org.wso2.carbon.bpmn.extensions.rest;
 
+import java.nio.charset.Charset;
 import org.apache.axiom.om.OMElement;
 import org.apache.axiom.om.util.AXIOMUtil;
 import org.apache.commons.codec.binary.Base64;
@@ -263,7 +264,7 @@ public class RESTInvoker {
         String output = null;
         try {
             httpPost = new HttpPost(uri);
-            httpPost.setEntity(new StringEntity(payload,StandardCharsets.UTF_8));
+            httpPost.setEntity(new StringEntity(payload, Charset.defaultCharset()));
             processHeaderList(httpPost, jsonHeaders);
             response = sendReceiveRequest(httpPost, username, password);
             if (response.getEntity() != null) {
@@ -312,7 +313,7 @@ public class RESTInvoker {
         String output = null;
         try {
             httpPut = new HttpPut(uri);
-            httpPut.setEntity(new StringEntity(payload,StandardCharsets.UTF_8));
+            httpPut.setEntity(new StringEntity(payload,Charset.defaultCharset()));
             processHeaderList(httpPut, jsonHeaders);
             response = sendReceiveRequest(httpPut, username, password);
             if (response.getEntity() != null) {

--- a/components/bpmn/org.wso2.carbon.bpmn.extensions/src/main/java/org/wso2/carbon/bpmn/extensions/rest/RESTInvoker.java
+++ b/components/bpmn/org.wso2.carbon.bpmn.extensions/src/main/java/org/wso2/carbon/bpmn/extensions/rest/RESTInvoker.java
@@ -263,7 +263,7 @@ public class RESTInvoker {
         String output = null;
         try {
             httpPost = new HttpPost(uri);
-            httpPost.setEntity(new StringEntity(payload));
+            httpPost.setEntity(new StringEntity(payload,StandardCharsets.UTF_8));
             processHeaderList(httpPost, jsonHeaders);
             response = sendReceiveRequest(httpPost, username, password);
             if (response.getEntity() != null) {
@@ -312,7 +312,7 @@ public class RESTInvoker {
         String output = null;
         try {
             httpPut = new HttpPut(uri);
-            httpPut.setEntity(new StringEntity(payload));
+            httpPut.setEntity(new StringEntity(payload,StandardCharsets.UTF_8));
             processHeaderList(httpPut, jsonHeaders);
             response = sendReceiveRequest(httpPut, username, password);
             if (response.getEntity() != null) {

--- a/components/bpmn/org.wso2.carbon.bpmn.rest/pom.xml
+++ b/components/bpmn/org.wso2.carbon.bpmn.rest/pom.xml
@@ -96,7 +96,7 @@
                         </resource>
                     </webResources>
                     <warName>bpmn</warName>
-                    <packagingExcludes>WEB-INF/lib/axis2-kernel-1.6.1-wso2v19.jar</packagingExcludes>
+                    <packagingExcludes>WEB-INF/lib/axis2-kernel-${axis2.version}.jar</packagingExcludes>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
An input payload that consists of Unicode characters in RESTTask (bpmn) are not handled properly(In both POST and PUT). Related git issue #924.

Also contains  fix for git issue #718.