### PR TITLE
[BPS-1173] Fix:Resuming BPS process instances after server reboot

### DIFF
--- a/components/bpel/org.wso2.carbon.bpel/src/main/java/org/wso2/carbon/bpel/core/ode/integration/BPELSchedulerInitializer.java
+++ b/components/bpel/org.wso2.carbon.bpel/src/main/java/org/wso2/carbon/bpel/core/ode/integration/BPELSchedulerInitializer.java
@@ -30,17 +30,15 @@ public class BPELSchedulerInitializer implements ServerStartupObserver {
 
     @Override
     public void completingServerStartup() {
-        if (log.isInfoEnabled()) {
-            log.info("Starting BPS Scheduler");
-            if (BPELServiceComponent.getBPELServer().getBpelServerConfiguration().getUseDistributedLock()) {
-                if (BPELServiceComponent.getHazelcastInstance() != null) {
-                    log.info("HazelCast instance available and configured");
-                } else {
-                    log.error("HazelCast instance not available, but distributed lock enabled");
-                }
+
+        if (BPELServiceComponent.getBPELServer().getBpelServerConfiguration().getUseDistributedLock()) {
+            if (BPELServiceComponent.getHazelcastInstance() != null) {
+                log.info("HazelCast instance available and configured");
+            } else {
+                log.error("HazelCast instance not available, but distributed lock enabled");
             }
         }
-        ((BPELServerImpl) BPELServiceComponent.getBPELServer()).getScheduler().start();
+
     }
 
     @Override
@@ -48,5 +46,10 @@ public class BPELSchedulerInitializer implements ServerStartupObserver {
         if (log.isDebugEnabled()) {
             log.debug("Competed server startup");
         }
+
+        /**Need to start the scheduler after all BPEL processes get deployed to resume currently active process instances.
+         Hence start scheduler after completing server startup. Users should configure Node ID in the bps.xml*/
+        log.info("Starting BPS Scheduler");
+        ((BPELServerImpl) BPELServiceComponent.getBPELServer()).getScheduler().start();
     }
 }

--- a/components/bpel/org.wso2.carbon.bpel/src/main/java/org/wso2/carbon/bpel/core/ode/integration/BPELSchedulerInitializer.java
+++ b/components/bpel/org.wso2.carbon.bpel/src/main/java/org/wso2/carbon/bpel/core/ode/integration/BPELSchedulerInitializer.java
@@ -30,7 +30,6 @@ public class BPELSchedulerInitializer implements ServerStartupObserver {
 
     @Override
     public void completingServerStartup() {
-
         if (BPELServiceComponent.getBPELServer().getBpelServerConfiguration().getUseDistributedLock()) {
             if (BPELServiceComponent.getHazelcastInstance() != null) {
                 log.info("HazelCast instance available and configured");
@@ -38,7 +37,6 @@ public class BPELSchedulerInitializer implements ServerStartupObserver {
                 log.error("HazelCast instance not available, but distributed lock enabled");
             }
         }
-
     }
 
     @Override


### PR DESCRIPTION
Fix to resume execution of process instance (which were running within a loop) after a restart. After a restart of WSO2 BPS server (which may include few minutes break), process instances that were ACTIVE at the time get frozen, meaning their status is ACTIVE, but their execution does not progress anymore.
**Note:** User have to set Node ID in bps.xml
Fix JIRA: https://wso2.org/jira/browse/BPS-1173