### PR TITLE
[EI-1055]Fix broken BPEL Process Navigation Links 

### DIFF
--- a/components/bpel/org.wso2.carbon.bpel.ui/src/main/resources/web/bpel/process_list.jsp
+++ b/components/bpel/org.wso2.carbon.bpel.ui/src/main/resources/web/bpel/process_list.jsp
@@ -209,7 +209,7 @@
             processListOrderBy = "-deployed";
         }
 
-        parameters = "filter=" + processListFilter + "&order=" + processListOrderBy+"&packageSearchString=" + packageSearchString;
+        parameters = "filter=" + URLEncoder.encode(processListFilter, "UTF-8") + "&order=" + processListOrderBy + "&packageSearchString=" + packageSearchString;
 
 
     }


### PR DESCRIPTION
Fixed broken BPEL process pagination links in bpel process list page (process_list.jsp). The process list filters were not URL encoded hence the above issue occurred in pagination links.