### PR TITLE
Fix wso2/product-ei/issues/1611

### DIFF
--- a/components/humantask/org.wso2.carbon.humantask/src/main/java/org/wso2/carbon/humantask/core/store/NotificationConfiguration.java
+++ b/components/humantask/org.wso2.carbon.humantask/src/main/java/org/wso2/carbon/humantask/core/store/NotificationConfiguration.java
@@ -95,7 +95,7 @@ public class NotificationConfiguration extends HumanTaskBaseConfiguration {
             endpointConfig.setServicePort(service.getPort());
             endpointConfig.setServiceNS(service.getName().getNamespaceURI());
             endpointConfig.setBasePath(getHumanTaskDefinitionFile().getParentFile().getAbsolutePath());
-
+            endpointConfig.setServiceDescriptionLocation(service.getServiceDescriptionReference());
             addEndpointConfiguration(endpointConfig);
         }
     }

--- a/components/humantask/org.wso2.carbon.humantask/src/main/java/org/wso2/carbon/humantask/core/store/TaskConfiguration.java
+++ b/components/humantask/org.wso2.carbon.humantask/src/main/java/org/wso2/carbon/humantask/core/store/TaskConfiguration.java
@@ -130,7 +130,7 @@ public class TaskConfiguration extends HumanTaskBaseConfiguration {
             endpointConfig.setServicePort(service.getPort());
             endpointConfig.setServiceNS(service.getName().getNamespaceURI());
             endpointConfig.setBasePath(getHumanTaskDefinitionFile().getParentFile().getAbsolutePath());
-
+            endpointConfig.setServiceDescriptionLocation(service.getServiceDescriptionReference());
             addEndpointConfiguration(endpointConfig);
         }
 
@@ -148,7 +148,7 @@ public class TaskConfiguration extends HumanTaskBaseConfiguration {
             endpointConfig.setServicePort(cbService.getPort());
             endpointConfig.setServiceNS(cbService.getName().getNamespaceURI());
             endpointConfig.setBasePath(getHumanTaskDefinitionFile().getParentFile().getAbsolutePath());
-
+            endpointConfig.setServiceDescriptionLocation(cbService.getServiceDescriptionReference());
             addEndpointConfiguration(endpointConfig);
         }
     }

--- a/components/humantask/org.wso2.carbon.humantask/src/main/java/org/wso2/carbon/humantask/core/utils/HumanTaskStoreUtils.java
+++ b/components/humantask/org.wso2.carbon.humantask/src/main/java/org/wso2/carbon/humantask/core/utils/HumanTaskStoreUtils.java
@@ -55,14 +55,8 @@ public final class HumanTaskStoreUtils {
     }
 
     public static EndpointConfiguration getEndpointConfig(OMElement serviceEle) {
-        OMElement endpointEle = serviceEle.getFirstElement();
-        if (endpointEle == null || !endpointEle.getQName().equals(
-                new QName(BusinessProcessConstants.BPEL_PKG_ENDPOINT_CONFIG_NS,
-                        BusinessProcessConstants.ENDPOINT))) {
-            return null;
-        }
 
-        String serviceDescLocation = endpointEle.getAttributeValue(new QName(null,
+        String serviceDescLocation = serviceEle.getAttributeValue(new QName(null,
                 BusinessProcessConstants.SERVICE_DESC_LOCATION));
 
         if (StringUtils.isNotEmpty(serviceDescLocation)) {
@@ -72,7 +66,7 @@ public final class HumanTaskStoreUtils {
             return endpointConfig;
         }
 
-        String endpointRef = endpointEle.getAttributeValue(new QName(null,
+        String endpointRef = serviceEle.getAttributeValue(new QName(null,
                 BusinessProcessConstants.ENDPOINTREF));
         if (StringUtils.isNotEmpty(endpointRef)) {
             EndpointConfiguration endpointConfig = new EndpointConfiguration();

--- a/components/humantask/org.wso2.carbon.humantask/src/main/resources/schemas/hi-config.xsd
+++ b/components/humantask/org.wso2.carbon.humantask/src/main/resources/schemas/hi-config.xsd
@@ -27,6 +27,7 @@
                     </xsd:sequence>
                     <xsd:attribute name="name" type="xsd:QName"/>
                     <xsd:attribute name="port" type="xsd:NCName"/>
+                    <xsd:attribute name="serviceDescriptionReference" type="xsd:string" use="optional"/>
                 </xsd:complexType>
             </xsd:element>
         </xsd:sequence>
@@ -40,6 +41,7 @@
                     </xsd:sequence>
                     <xsd:attribute name="name" type="xsd:QName"/>
                     <xsd:attribute name="port" type="xsd:NCName"/>
+                    <xsd:attribute name="serviceDescriptionReference" type="xsd:string" use="optional"/>
                 </xsd:complexType>
             </xsd:element>
         </xsd:sequence>


### PR DESCRIPTION
## Purpose
> Fix wso2/product-ei/issues/1611

## Goals
> This fix enables BPS human-tasks to point to a service xml file to pick only necessary transports rather than taking default transports from axis2.xml file.

## Approach
> Introduce parameter serviceDescriptionReference for BPS human-tasks which was already working for BPEL

## Test environment
> JDK 8, Ubuntu 16.04