### PR TITLE
Add cookie consent to BPMN/Human-task explorers

### DIFF
--- a/components/bpmn/bpmn-explorer-web/src/web/config/config.json
+++ b/components/bpmn/bpmn-explorer-web/src/web/config/config.json
@@ -1,17 +1,19 @@
 {
-    "app": {
-	"title" : "BPMN Explorer",
-	"author": "WSO2 Business Process Server",
-	"footer": "&copy; 2005 - 2015 WSO2 Inc. All Rights Reserved."
-    },
-    "server": {
-        "https": "%https.host%",
-        "http": "%http.host%",
-        "bpsHost":"",
-        "bpsPort":"",
-        "bpsTenantDomain": "",
-        "bpsTenantId" : ""
-    }
+  "app": {
+    "title": "BPMN Explorer",
+    "author": "WSO2 Business Process Server",
+    "footer": "&copy; 2005 - 2018 WSO2 Inc. All Rights Reserved.",
+    "enablePrivacyPolicy": true,
+    "privacyPolicyLink": "%https.host%"
+  },
+  "server": {
+    "https": "%https.host%",
+    "http": "%http.host%",
+    "bpsHost": "",
+    "bpsPort": "",
+    "bpsTenantDomain": "",
+    "bpsTenantId": ""
+  }
 }
 
 

--- a/components/bpmn/bpmn-explorer-web/src/web/config/locales/locale_en.json
+++ b/components/bpmn/bpmn-explorer-web/src/web/config/locales/locale_en.json
@@ -168,6 +168,7 @@
    "go.back.to.my.substitution.view" : "Go Back To My Substitution View",
    "you.have.admin.access.to.manage.substitutions" : "You Have Admin Access To Manage Substitutions",
    "you.are.in.the.user.substitutions.admin.view" : "You are in the User Substitutions Admin View",
-   "unauthorized" : "Unauthorized"
-
+   "unauthorized" : "Unauthorized",
+   "cookie.policy": "This site uses cookies. By logging in to the site, you are agreeing on the usage of cookies. For more information, refer",
+   "cookie.policy.link.label": "WSO2 cookie policy"
 }

--- a/components/bpmn/bpmn-explorer-web/src/web/model/loginModel.jag
+++ b/components/bpmn/bpmn-explorer-web/src/web/model/loginModel.jag
@@ -20,4 +20,6 @@ if(loginFailed){
 	message = "Username or password invalid!";
 	session.remove("loginFailed");
 }
+var isPrivacyPolicyEnabled = data.app.enablePrivacyPolicy;
+var privacyPolicyLink = data.app.privacyPolicyLink;
 %>

--- a/components/bpmn/bpmn-explorer-web/src/web/template/loginView.jag
+++ b/components/bpmn/bpmn-explorer-web/src/web/template/loginView.jag
@@ -32,6 +32,11 @@
                         </div>
 
                         <div class="wr-input-control padding-bottom-double padding-left-double padding-right-double">
+                        <% if (isPrivacyPolicyEnabled) { %>
+                            <div class="alert alert-warning" role="alert"><%=i18n.localize("cookie.policy", "Cookie Policy")%>
+                            <a href="<%=privacyPolicyLink%>"><%=i18n.localize("cookie.policy.link.label", "Cookie Policy Link")%></a>.
+                            </div>
+                        <% } %>
                         <% if (message != "") { %>
                                 <div class="alert alert-danger" role="alert"><%=message%></div>
                             <% } %>

--- a/components/humantask/humantask-explorer-web/src/web/config/config.json
+++ b/components/humantask/humantask-explorer-web/src/web/config/config.json
@@ -1,17 +1,19 @@
 {
-    "app": {
-	"title" : "HumanTask Explorer",
-	"author": "WSO2 Business Process Server",
-	"footer": "&copy; 2005 - 2015 WSO2 Inc. All Rights Reserved.",
-	"webappUrlName": "humantask-explorer"
-    },
-    "server": {
-        "https": "%https.host%",
-        "http": "%http.host%",
-        "bpsHost": "",
-        "bpsPort": "",
-        "bpsTenant": ""
-    }
+  "app": {
+    "title" : "HumanTask Explorer",
+    "author": "WSO2 Business Process Server",
+    "footer": "&copy; 2005 - 2018 WSO2 Inc. All Rights Reserved.",
+    "webappUrlName": "humantask-explorer",
+    "enablePrivacyPolicy": true,
+    "privacyPolicyLink": "%https.host%"
+  },
+  "server": {
+    "https": "%https.host%",
+    "http": "%http.host%",
+    "bpsHost": "",
+    "bpsPort": "",
+    "bpsTenant": ""
+  }
 }
 
 

--- a/components/humantask/humantask-explorer-web/src/web/config/locales/locale_en.json
+++ b/components/humantask/humantask-explorer-web/src/web/config/locales/locale_en.json
@@ -106,5 +106,7 @@
   "no":"No",
   "yes":"Yes",
   "category":"Category",
-  "search.result":"Search Results"
+  "search.result":"Search Results",
+  "cookie.policy": "This site uses cookies. By logging in to the site, you are agreeing on the usage of cookies. For more information, refer",
+  "cookie.policy.link.label": "WSO2 cookie policy"
 }

--- a/components/humantask/humantask-explorer-web/src/web/model/loginModel.jag
+++ b/components/humantask/humantask-explorer-web/src/web/model/loginModel.jag
@@ -22,4 +22,6 @@
         message = "Username or password invalid!";
         session.remove("loginFailed");
     }
+    var isPrivacyPolicyEnabled = data.app.enablePrivacyPolicy;
+    var privacyPolicyLink = data.app.privacyPolicyLink;
 %>

--- a/components/humantask/humantask-explorer-web/src/web/template/loginView.jag
+++ b/components/humantask/humantask-explorer-web/src/web/template/loginView.jag
@@ -34,6 +34,11 @@
                         </div>
 
                         <div class="wr-input-control padding-bottom-double padding-left-double padding-right-double">
+                        <% if (isPrivacyPolicyEnabled) { %>
+                            <div class="alert alert-warning" role="alert"><%=i18n.localize("cookie.policy", "Cookie Policy")%>
+                            <a href="<%=privacyPolicyLink%>"><%=i18n.localize("cookie.policy.link.label", "Cookie Policy Link")%></a>.
+                            </div>
+                        <% } %>
                         <% if (message != "") { %>
                                 <div class="alert alert-danger" role="alert"><%=message%></div>
                             <% } %>


### PR DESCRIPTION
## Purpose
> The purpose of this change to introduce a cookie consent to Human-Task and BPMN explorer login pages in order to comply with GDPR

## Approach
> Added a banner to notify users about the cookie policy of the organization. It is added as in a configurable manner where admin can either enable/disable the banner by changing the property provided in config.json.

## User stories
<img width="615" alt="screen shot 2018-02-21 at 10 02 51 am" src="https://user-images.githubusercontent.com/11870191/36463217-6ffe6876-16ee-11e8-90ea-003e5035a65b.png">

