### PR TITLE
Expose internal dependencies for geronimo 3.0.1 through bpel component.

### DIFF
--- a/components/bpel/org.wso2.carbon.bpel/pom.xml
+++ b/components/bpel/org.wso2.carbon.bpel/pom.xml
@@ -61,6 +61,30 @@
             <groupId>org.wso2.carbon</groupId>
             <artifactId>org.wso2.carbon.utils</artifactId>
         </dependency>
+        <!-- geronimo framework 3.0.1 related dependencies -->
+        <dependency>
+            <groupId>com.thoughtworks.xstream</groupId>
+            <artifactId>xstream</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>cglib</groupId>
+            <artifactId>cglib</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.geronimo.framework</groupId>
+            <artifactId>geronimo-crypto</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.xbean</groupId>
+            <artifactId>xbean-bundleutils</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.xbean</groupId>
+            <artifactId>xbean-reflect</artifactId>
+        </dependency>
+
+
+
         <!--<dependency>-->
         <!--<groupId>org.wso2.carbon</groupId>-->
         <!--<artifactId>org.wso2.carbon.datasource</artifactId>-->
@@ -185,7 +209,12 @@
                         </Private-Package>
                         <Export-Package>
                             !org.wso2.carbon.bpel.core.internal,
-                            org.wso2.carbon.bpel.core.*
+                            org.wso2.carbon.bpel.core.*,
+                            com.thoughtworks.xstream.*;version="${com.thoughtworks.xstream.version}",
+                            net.sf.cglib.asm.*;version="${cglib.version}",
+                            org.apache.geronimo.crypto.*,
+                            org.apache.xbean.osgi.bundle.util.*;version="${xbean.bundleutils.version}",
+                            org.apache.xbean.recipe.*;version="${xbean.reflect.version}"
                         </Export-Package>
                         <Import-Package>
                             !org.wso2.carbon.bpel.core,
@@ -196,6 +225,11 @@
                             version="${carbon.business-process.imp.pkg.version}",
                             org.wso2.carbon.bpel.skeleton.ode.integration.mgt.services.*;
                             version="${carbon.business-process.imp.pkg.version}",
+                            !com.thoughtworks.xstream.*;version="${com.thoughtworks.xstream.version}",
+                            !net.sf.cglib.asm.*;version="${cglib.version}",
+                            !org.apache.geronimo.crypto.*,
+                            !org.apache.xbean.osgi.bundle.util.*;version="${xbean.bundleutils.version}",
+                            !org.apache.xbean.recipe.*;version="${xbean.reflect.version}"
                             *;resolution:=optional
                         </Import-Package>
                         <DynamicImport-Package>*</DynamicImport-Package>

--- a/pom.xml
+++ b/pom.xml
@@ -1158,6 +1158,34 @@
                 <artifactId>encoder</artifactId>
                 <version>${orbit.encoder.wso2.version}</version>
             </dependency>
+
+            <!-- geronimo framework 3.0.1 related dependencies -->
+            <dependency>
+                <groupId>com.thoughtworks.xstream</groupId>
+                <artifactId>xstream</artifactId>
+                <version>${com.thoughtworks.xstream.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>cglib</groupId>
+                <artifactId>cglib</artifactId>
+                <version>${cglib.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.geronimo.framework</groupId>
+                <artifactId>geronimo-crypto</artifactId>
+                <version>${geronimo.crypto.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.xbean</groupId>
+                <artifactId>xbean-bundleutils</artifactId>
+                <version>${xbean.bundleutils.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.xbean</groupId>
+                <artifactId>xbean-reflect</artifactId>
+                <version>${xbean.reflect.version}</version>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 
@@ -1664,6 +1692,12 @@
 
         <!--WSO2 Encoder Version-->
         <orbit.encoder.wso2.version>1.2.0.wso2v2</orbit.encoder.wso2.version>
+
+        <com.thoughtworks.xstream.version>1.3</com.thoughtworks.xstream.version>
+        <cglib.version>2.1</cglib.version>
+        <geronimo.crypto.version>3.0.1</geronimo.crypto.version>
+        <xbean.bundleutils.version>3.13</xbean.bundleutils.version>
+        <xbean.reflect.version>3.11</xbean.reflect.version>
     </properties>
 
 


### PR DESCRIPTION
The Geronimo framework mandates these dependencies to be visible in OSGI runtime.

The eventual proper solution should be to take geronimo-kernel 3.0.1 into WSO2 orbit as an osgi bundle and then expose these dependencies from there instead of the BPEL profile. 