### PR TITLE
Fix to enable Secure vault for the properties defined within the activity.xml

### DIFF
--- a/components/bpmn/org.wso2.carbon.bpmn/src/main/java/org/wso2/carbon/bpmn/core/ActivitiEngineBuilder.java
+++ b/components/bpmn/org.wso2.carbon.bpmn/src/main/java/org/wso2/carbon/bpmn/core/ActivitiEngineBuilder.java
@@ -1,17 +1,17 @@
 /**
- *  Copyright (c) 2014 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ * Copyright (c) 2014 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.wso2.carbon.bpmn.core;
@@ -45,71 +45,91 @@ import org.activiti.engine.impl.variable.StringType;
 import org.activiti.engine.impl.variable.UUIDType;
 import org.activiti.engine.impl.variable.VariableType;
 import org.activiti.engine.impl.variable.VariableTypes;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.bpmn.core.integration.BPSGroupManagerFactory;
 import org.wso2.carbon.bpmn.core.integration.BPSUserManagerFactory;
 import org.wso2.carbon.bpmn.core.types.datatypes.json.ExtendedJsonType;
 import org.wso2.carbon.bpmn.core.types.datatypes.json.JsonAPIResolverFactory;
 import org.wso2.carbon.bpmn.core.types.datatypes.xml.XmlAPIResolverFactory;
 import org.wso2.carbon.bpmn.core.types.datatypes.xml.XmlType;
+import org.wso2.carbon.bpmn.core.utils.SecretVaultValueReader;
 import org.wso2.carbon.utils.CarbonUtils;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
 /**
  * Class responsible for building and initiating the activiti engine
- *
  */
 public class ActivitiEngineBuilder {
-
-	private static final Log log = LogFactory.getLog(ActivitiEngineBuilder.class);
-
-	private String dataSourceJndiName = null;
     private static ProcessEngine processEngine = null;
     protected ObjectMapper objectMapper = new ObjectMapper();//Object mapper for JsonType,ExtendedJsonType,LongJsonType
+    private String dataSourceJndiName = null;
 
-	 /* Instantiates the engine. Builds the state of the engine
-	 *
-	 * @return  ProcessEngineImpl object
-	 * @throws BPSFault  Throws in the event of failure of ProcessEngine
-	 */
+    /* Instantiates the engine. Builds the state of the engine
+     *
+     * @return  ProcessEngineImpl object
+     * @throws BPSFault  Throws in the event of failure of ProcessEngine
+     */
+    public static ProcessEngine getProcessEngine() {
+        return ActivitiEngineBuilder.processEngine;
+    }
 
     public ProcessEngine buildEngine() throws BPSFault {
+        String carbonConfigDirPath = CarbonUtils.getCarbonConfigDirPath();
+        String activitiConfigPath = carbonConfigDirPath + File.separator +
+                BPMNConstants.ACTIVITI_CONFIGURATION_FILE_NAME;
+        File activitiConfigFile = new File(activitiConfigPath);
+        ProcessEngineConfigurationImpl processEngineConfigurationImpl = null;
+        Boolean hasNoSecretValue = true;
 
-        try {
-            String carbonConfigDirPath = CarbonUtils.getCarbonConfigDirPath();
-            String activitiConfigPath = carbonConfigDirPath + File.separator +
-                    BPMNConstants.ACTIVITI_CONFIGURATION_FILE_NAME;
-            File activitiConfigFile = new File(activitiConfigPath);
-            ProcessEngineConfigurationImpl processEngineConfigurationImpl =
-                    (ProcessEngineConfigurationImpl) ProcessEngineConfiguration.createProcessEngineConfigurationFromInputStream(
-                            new FileInputStream(
-                                    activitiConfigFile));
+        //Initialize the secretResolver
+        SecretVaultValueReader secretVaultValueReader = new SecretVaultValueReader(activitiConfigFile);
 
-            //Add script engine resolvers
-            setResolverFactories(processEngineConfigurationImpl);
-            //Add supported variable types
-            setSupportedVariableTypes(processEngineConfigurationImpl);
+        //If the secretResolver is not null then we decrypt the file
+        if (secretVaultValueReader.getSecretResolver() != null && secretVaultValueReader.getSecretResolver().isInitialized()) {
+            InputStream decryptedConfigElement = secretVaultValueReader.decryptSecretValues();
 
-            // we have to build the process engine first to initialize session factories.
-            processEngine = processEngineConfigurationImpl.buildProcessEngine();
-            processEngineConfigurationImpl.getSessionFactories().put(UserIdentityManager.class,
-                    new BPSUserManagerFactory());
-            processEngineConfigurationImpl.getSessionFactories().put(GroupIdentityManager.class,
-                    new BPSGroupManagerFactory());
+            if (decryptedConfigElement != null) {
+                hasNoSecretValue = false;
+                processEngineConfigurationImpl = (ProcessEngineConfigurationImpl) ProcessEngineConfiguration.
+                        createProcessEngineConfigurationFromInputStream(decryptedConfigElement);
+            }
 
-            dataSourceJndiName = processEngineConfigurationImpl.getProcessEngineConfiguration()
-                    .getDataSourceJndiName();
-
-        } catch (FileNotFoundException e) {
-            String msg = "Failed to create an Activiti engine. Activiti configuration file not found";
-            throw new BPSFault(msg, e);
         }
+
+        if (hasNoSecretValue) {
+            try {
+                processEngineConfigurationImpl =
+                        (ProcessEngineConfigurationImpl) ProcessEngineConfiguration.
+                                createProcessEngineConfigurationFromInputStream(
+                                        new FileInputStream(activitiConfigFile)
+                                );
+            } catch (FileNotFoundException e) {
+                String msg = "Failed to create an Activiti engine. Activiti configuration file not found";
+                throw new BPSFault(msg, e);
+            }
+        }
+
+        //Add script engine resolvers
+        setResolverFactories(processEngineConfigurationImpl);
+        //Add supported variable types
+        setSupportedVariableTypes(processEngineConfigurationImpl);
+
+        // we have to build the process engine first to initialize session factories.
+        processEngine = processEngineConfigurationImpl.buildProcessEngine();
+        processEngineConfigurationImpl.getSessionFactories().put(UserIdentityManager.class,
+                new BPSUserManagerFactory());
+        processEngineConfigurationImpl.getSessionFactories().put(GroupIdentityManager.class,
+                new BPSGroupManagerFactory());
+
+        dataSourceJndiName = processEngineConfigurationImpl.getProcessEngineConfiguration()
+                .getDataSourceJndiName();
+
+
         return processEngine;
     }
 
@@ -117,20 +137,17 @@ public class ActivitiEngineBuilder {
         return dataSourceJndiName;
     }
 
-    public static ProcessEngine getProcessEngine(){
-        return ActivitiEngineBuilder.processEngine;
-    }
-
     /**
      * Function to set supported variable types
+     *
      * @param processEngineConfiguration
      */
-    private void setSupportedVariableTypes (ProcessEngineConfigurationImpl processEngineConfiguration) {
+    private void setSupportedVariableTypes(ProcessEngineConfigurationImpl processEngineConfiguration) {
         VariableTypes variableTypes = new DefaultVariableTypes();
 
         List<VariableType> customPreVariableTypes = processEngineConfiguration.getCustomPreVariableTypes();
-        if (customPreVariableTypes!=null) {
-            for (VariableType customVariableType: customPreVariableTypes) {
+        if (customPreVariableTypes != null) {
+            for (VariableType customVariableType : customPreVariableTypes) {
                 variableTypes.addType(customVariableType);
             }
         }
@@ -145,21 +162,24 @@ public class ActivitiEngineBuilder {
         variableTypes.addType(new LongType());
         variableTypes.addType(new DateType());
         variableTypes.addType(new DoubleType());
-        variableTypes.addType(new UUIDType());;
-        variableTypes.addType(new JsonType(ProcessEngineConfigurationImpl.DEFAULT_ORACLE_MAX_LENGTH_STRING, objectMapper));
-        variableTypes.addType(new LongJsonType(ProcessEngineConfigurationImpl.DEFAULT_ORACLE_MAX_LENGTH_STRING + 1, objectMapper));
+        variableTypes.addType(new UUIDType());
+        variableTypes.addType(new JsonType(ProcessEngineConfigurationImpl.DEFAULT_ORACLE_MAX_LENGTH_STRING,
+                objectMapper));
+        variableTypes.addType(new LongJsonType(ProcessEngineConfigurationImpl.DEFAULT_ORACLE_MAX_LENGTH_STRING + 1,
+                objectMapper));
         variableTypes.addType(new ByteArrayType());
         variableTypes.addType(new SerializableType());
         variableTypes.addType(new CustomObjectType("item", ItemInstance.class));
         variableTypes.addType(new CustomObjectType("message", MessageInstance.class));
 
         //types added for WSO2 BPS
-        variableTypes.addType(new ExtendedJsonType(ProcessEngineConfigurationImpl.DEFAULT_ORACLE_MAX_LENGTH_STRING, objectMapper));
+        variableTypes.addType(new ExtendedJsonType(ProcessEngineConfigurationImpl.DEFAULT_ORACLE_MAX_LENGTH_STRING,
+                objectMapper));
         variableTypes.addType(new XmlType());
 
-        List<VariableType> customPostVariableTypes =processEngineConfiguration.getCustomPostVariableTypes();
+        List<VariableType> customPostVariableTypes = processEngineConfiguration.getCustomPostVariableTypes();
         if (customPostVariableTypes != null) {
-            for (VariableType customVariableType: customPostVariableTypes) {
+            for (VariableType customVariableType : customPostVariableTypes) {
                 variableTypes.addType(customVariableType);
             }
         }
@@ -169,10 +189,11 @@ public class ActivitiEngineBuilder {
 
     /**
      * Function to register resolver factories that used by script engines and JUEL
+     *
      * @param processEngineConfiguration
      */
-    private void setResolverFactories (ProcessEngineConfigurationImpl processEngineConfiguration) {
-        List <ResolverFactory> resolverFactories = new ArrayList<>();
+    private void setResolverFactories(ProcessEngineConfigurationImpl processEngineConfiguration) {
+        List<ResolverFactory> resolverFactories = new ArrayList<>();
         //Resolvers from Activiti
         resolverFactories.add(new VariableScopeResolverFactory());
         resolverFactories.add(new BeansResolverFactory());

--- a/components/bpmn/org.wso2.carbon.bpmn/src/main/java/org/wso2/carbon/bpmn/core/BPMNConstants.java
+++ b/components/bpmn/org.wso2.carbon.bpmn/src/main/java/org/wso2/carbon/bpmn/core/BPMNConstants.java
@@ -76,5 +76,9 @@ public class BPMNConstants {
      * {@value #RESOLVE_DEPLOYMENT_SYS_PROP} System property to avoid resolving deployment to avoid inconsistencies
      */
     public static final String RESOLVE_DEPLOYMENT_SYS_PROP = "resolveDeploymentsAtStartup";
+
+    //For secure vault implementation in ActivitiEngine
+    public static final String SECURE_VAULT_NS = "http://org.wso2.securevault/configuration";
+    public static final String SECRET_ALIAS_ATTR_NAME = "secretAlias";
 }
 

--- a/components/bpmn/org.wso2.carbon.bpmn/src/main/java/org/wso2/carbon/bpmn/core/utils/SecretVaultValueReader.java
+++ b/components/bpmn/org.wso2.carbon.bpmn/src/main/java/org/wso2/carbon/bpmn/core/utils/SecretVaultValueReader.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.carbon.bpmn.core.utils;
+
+import org.apache.axiom.om.OMAttribute;
+import org.apache.axiom.om.OMElement;
+import org.apache.axiom.om.impl.builder.StAXOMBuilder;
+import org.wso2.carbon.bpmn.core.BPMNConstants;
+import org.wso2.carbon.bpmn.core.BPSFault;
+import org.wso2.securevault.SecretResolver;
+import org.wso2.securevault.SecretResolverFactory;
+
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLStreamException;
+import java.util.Iterator;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.io.IOException;
+import java.io.ByteArrayInputStream;
+
+/**
+ * This class provides the functionality to read the value from SecureVault
+ */
+public class SecretVaultValueReader {
+    private OMElement activitiConfigElement;
+    private SecretResolver secretResolver;
+
+    /**
+     * Constructor to initialize SecretResolver object
+     *
+     * @param activitiConfigFile The activit.xml file that contains the aliases
+     */
+    public SecretVaultValueReader(File activitiConfigFile) throws BPSFault {
+        try (FileInputStream fileInputStream = new FileInputStream(activitiConfigFile)) {
+            StAXOMBuilder builder = new StAXOMBuilder(fileInputStream);
+            activitiConfigElement = builder.getDocumentElement();
+            secretResolver = SecretResolverFactory.create(activitiConfigElement, true);
+        } catch (XMLStreamException | IOException e) {
+            throw new BPSFault("Failed to find activiti.xml", e);
+        }
+    }
+
+    /**
+     * Function that iterates through each property in the file and calls getSecretValue() to check if it has a
+     * secretAlias
+     *
+     * @return InputStream of the activiti.xml file with the resolved secretAliases. Returns null if there are no
+     * secret alias attributes in any of the properties
+     */
+    public InputStream decryptSecretValues() {
+        boolean hasSecretValue = false;
+
+        Iterator iteratorBeans = activitiConfigElement.getChildrenWithLocalName("bean");
+
+        while (iteratorBeans.hasNext()) {
+
+            Iterator iteratorProperties = ((OMElement) iteratorBeans.next()).getChildrenWithLocalName("property");
+            while (iteratorProperties.hasNext()) {
+                OMElement propertyOMElement = (OMElement) iteratorProperties.next();
+                String secretValue = getSecureVaultValue(secretResolver, propertyOMElement);
+
+                if (secretValue != null) {
+                    hasSecretValue = true;
+                    propertyOMElement.addAttribute("value", secretValue, null);
+                    propertyOMElement.removeAttribute(
+                            propertyOMElement.getAttribute(
+                                    new QName(BPMNConstants.SECURE_VAULT_NS, BPMNConstants.SECRET_ALIAS_ATTR_NAME)
+                            )
+                    );
+                }
+            } //End of iteration through iteratorProperties
+        } //End of iteration through iteratorBeans
+
+        if (hasSecretValue) {
+            InputStream activitiConfigStream = new ByteArrayInputStream(activitiConfigElement.toString().getBytes());
+            return activitiConfigStream;
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Function to get the SecureVault value as a string.
+     *
+     * @param secretResolver  SecretResolver that resolves the password in the SecureVault
+     * @param propertyElement Parameter that needs to be resolved
+     * @return Resolved password as a String. Returns null if secretAlias attribute doesnt exist
+     */
+    private String getSecureVaultValue(SecretResolver secretResolver, OMElement propertyElement) {
+        String value = null;
+        OMAttribute attribute;
+
+        if (propertyElement != null) {
+            attribute = propertyElement.getAttribute(
+                    new QName(BPMNConstants.SECURE_VAULT_NS, "secretAlias")
+            );
+
+            if (attribute != null) {
+                value = secretResolver.resolve(attribute.getAttributeValue());
+            }
+        }
+        return value;
+    }
+
+    public SecretResolver getSecretResolver() {
+        return this.secretResolver;
+    }
+}


### PR DESCRIPTION
- Added SecretVaultValueReader class to convert properties with
secretAlias attributes to the corresponding password stored in the
Secure Vault
- If secretAlias attributes exist, the file is decrypted and converted
to an InputStream. Otherwise, the file is passed as a FileInputStream.

Resolves : https://github.com/wso2/product-ei/issues/3246
