### PR TITLE
Upgrade json smart version

### DIFF
--- a/features/bpmn/org.wso2.carbon.bpmn.server.feature/pom.xml
+++ b/features/bpmn/org.wso2.carbon.bpmn.server.feature/pom.xml
@@ -184,6 +184,8 @@
 
                                 <importBundleDef>org.wso2.orbit.com.jayway.jsonpath:json-path:${jsonpath.wso2.version}</importBundleDef>
                                 <importBundleDef>net.minidev:json-smart:${json.smart.version}</importBundleDef>
+                                <importBundleDef>net.minidev:accessors-smart:${accessors-smart.version}</importBundleDef>
+                                <importBundleDef>org.ow2.asm:asm:${org.ow2.asm.asm.version}</importBundleDef>
 
                             </importBundles>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1648,6 +1648,8 @@
         <commons.fileupload.version>1.2.2</commons.fileupload.version>
         <jsonpath.wso2.version>2.4.0.wso2v2</jsonpath.wso2.version>
         <json.smart.version>2.3</json.smart.version>
+        <accessors-smart.version>1.2</accessors-smart.version>
+        <org.ow2.asm.asm.version>5.2</org.ow2.asm.asm.version>
 
 
         <!-- Servlet API -->

--- a/pom.xml
+++ b/pom.xml
@@ -1647,7 +1647,7 @@
         <commons.io.version>2.0.1</commons.io.version>
         <commons.fileupload.version>1.2.2</commons.fileupload.version>
         <jsonpath.wso2.version>2.4.0.wso2v2</jsonpath.wso2.version>
-        <json.smart.version>2.2</json.smart.version>
+        <json.smart.version>2.3</json.smart.version>
 
 
         <!-- Servlet API -->


### PR DESCRIPTION
Upgraded json-smart to version 2.3 and packed its transitive dependencies.