### PR TITLE
Fix the issue with case insensitive user names

### DIFF
--- a/components/humantask/org.wso2.carbon.humantask/src/main/java/org/wso2/carbon/humantask/core/api/client/TaskOperationsImpl.java
+++ b/components/humantask/org.wso2.carbon.humantask/src/main/java/org/wso2/carbon/humantask/core/api/client/TaskOperationsImpl.java
@@ -25,6 +25,7 @@ import org.apache.commons.logging.LogFactory;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.wso2.carbon.context.CarbonContext;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.core.AbstractAdmin;
 import org.wso2.carbon.humantask.client.api.*;
 import org.wso2.carbon.humantask.client.api.types.*;
@@ -81,6 +82,7 @@ import org.wso2.carbon.registry.core.exceptions.RegistryException;
 import org.wso2.carbon.registry.core.service.RegistryService;
 import org.wso2.carbon.user.core.UserRealm;
 import org.wso2.carbon.user.core.UserStoreException;
+import org.wso2.carbon.user.core.util.UserCoreUtil;
 
 import javax.xml.namespace.QName;
 import java.util.*;
@@ -1696,7 +1698,6 @@ public class TaskOperationsImpl extends AbstractAdmin
             throw new HumanTaskRuntimeException("Cannot determine the user name of the user " +
                     "performing the task operation!");
         }
-
         return userName;
     }
 

--- a/components/humantask/org.wso2.carbon.humantask/src/main/java/org/wso2/carbon/humantask/core/dao/sql/HumanTaskJPQLQueryBuilder.java
+++ b/components/humantask/org.wso2.carbon.humantask/src/main/java/org/wso2/carbon/humantask/core/dao/sql/HumanTaskJPQLQueryBuilder.java
@@ -256,7 +256,7 @@ public class HumanTaskJPQLQueryBuilder {
         }
         Query assignedToMeQuery = em.createQuery(SELECT_DISTINCT_TASKS +
                 JOIN_HUMAN_ROLES_JOIN_ORG_ENTITIES +
-                " oe.name = :name " +
+                "LOWER(oe.name) = LOWER(:name) " +
                 AND +
                 HR_TYPE_ROLE_TYPE +
                 AND +
@@ -484,7 +484,7 @@ public class HumanTaskJPQLQueryBuilder {
 
         Query assignedToMeQuery = em.createQuery(SELECT_DISTINCT_TASKS_COUNT +
                 JOIN_HUMAN_ROLES_JOIN_ORG_ENTITIES +
-                " oe.name = :name " +
+                "LOWER(oe.name) = LOWER(:name) " +
                 AND +
                 HR_TYPE_ROLE_TYPE +
                 AND +

--- a/components/humantask/org.wso2.carbon.humantask/src/main/java/org/wso2/carbon/humantask/core/engine/util/OperationAuthorizationUtil.java
+++ b/components/humantask/org.wso2.carbon.humantask/src/main/java/org/wso2/carbon/humantask/core/engine/util/OperationAuthorizationUtil.java
@@ -66,8 +66,10 @@ public final class OperationAuthorizationUtil {
                             entityForRole.getOrgEntityType())) {
                         String roleName = entityForRole.getName();
                         List<String> userListForRole = pqe.getUserNameListForRole(roleName);
-                        if (userListForRole.contains(validatee.getName())) {
-                            return true;
+                        for (String userName : userListForRole) {
+                            if (validatee.getName().equalsIgnoreCase(userName)) {
+                                return true;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Purpose
Fix the issue with case insensitive user names when a user logged into Admin portal with case insensitive username
When a user who has the role privileges to perform subscription approval in BPS human tasks tries to log to the EI console with a username with different cases from the original user name created in BPS, subscription approval fails.

Fixes the issue https://github.com/wso2/product-ei/issues/2263





