### PR TITLE
Fixes the issue Error in worker nodes when deploying BPEL process

### DIFF
--- a/components/bpel/org.wso2.carbon.bpel/src/main/java/org/wso2/carbon/bpel/core/BPELConstants.java
+++ b/components/bpel/org.wso2.carbon.bpel/src/main/java/org/wso2/carbon/bpel/core/BPELConstants.java
@@ -313,4 +313,6 @@ public final class BPELConstants {
             = "ode.secondary.stale.node.detection.threshold.factor";
 
     public static final String BPS_CLUSTER_NODE_MAP = "WSO2_BPS_NODE_ID_MAP";
+
+    public static final String DEPLOY_SYSTEM_PATH = "bps.bpelDeploy.deployTimeout";
 }

--- a/components/bpel/org.wso2.carbon.bpel/src/main/java/org/wso2/carbon/bpel/core/ode/integration/config/BPELServerConfiguration.java
+++ b/components/bpel/org.wso2.carbon.bpel/src/main/java/org/wso2/carbon/bpel/core/ode/integration/config/BPELServerConfiguration.java
@@ -127,6 +127,8 @@ public class BPELServerConfiguration {
     //Maximum length of a instance variable in instance view.
     private int instanceViewVariableLength = BPELConstants.DEFAULT_INSTANCE_VIEW_VARIABLE_LENGTH;
     private int transactionManagerTimeout = -1;
+    //DeployTimeout Configuration
+    private long deployTimeout = 60000;
 
     public BPELServerConfiguration() {
         if (log.isDebugEnabled()) {
@@ -135,6 +137,12 @@ public class BPELServerConfiguration {
 
         populateDefaultOpenJPAProps();
         loadBPELServerConfigurationFile();
+    }
+
+    private static BPELServerConfiguration BPELServerConfInstance = new BPELServerConfiguration();
+
+    public static BPELServerConfiguration getInstance() {
+        return BPELServerConfInstance;
     }
 
     public static void processACleanup(Set<ProcessConf.CLEANUP_CATEGORY> categories,
@@ -233,6 +241,11 @@ public class BPELServerConfiguration {
 
     public int getMexTimeOut() {
         return mexTimeOut;
+    }
+
+    // Return the deploy timeout in milli seconds defined in the BPS.xml configurations
+    public long getDeployTimeOut() {
+        return deployTimeout;
     }
 
     public int getExternalServiceTimeOut() {
@@ -469,6 +482,7 @@ public class BPELServerConfiguration {
         populateInstanceViewVariableLength();
         populateBpelInstanceDeletionLimit();
         populateTransactionManagerTimeout();
+        populateGetDeploymentTimeout();
     }
 
     /**
@@ -621,6 +635,16 @@ public class BPELServerConfiguration {
         TBPS.MexTimeOut timeOut = bpsConfigDocument.getWSO2BPS().getMexTimeOut();
         if (timeOut != null) {
             this.mexTimeOut = timeOut.getValue();
+        }
+    }
+
+    private void populateGetDeploymentTimeout() {
+        if (System.getProperty(BPELConstants.DEPLOY_SYSTEM_PATH) != null) {
+            this.deployTimeout = Long.parseLong(System.getProperty(BPELConstants.DEPLOY_SYSTEM_PATH)) ;
+        } else {
+            if (bpsConfigDocument.getWSO2BPS().getBpelDeploy() != null ) {
+                this.deployTimeout = bpsConfigDocument.getWSO2BPS().getBpelDeploy().getDeployTimeOut();
+            }
         }
     }
 

--- a/components/bpel/org.wso2.carbon.bpel/src/main/resources/schemas/bps.xsd
+++ b/components/bpel/org.wso2.carbon.bpel/src/main/resources/schemas/bps.xsd
@@ -65,8 +65,11 @@
             <xsd:element name="UseInstanceStateCache" type="xsd:string" minOccurs="0" maxOccurs="1"/>
             <xsd:element name="PersistenceProvider" type="xsd:string" minOccurs="0" maxOccurs="1"></xsd:element>
             <xsd:element name="NodeId" type="xsd:string" minOccurs="0" maxOccurs="1"></xsd:element>
-            <xsd:element name="ODESchedulerConfiguration" type="tns:simpleSchedulerConfig" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="ODESchedulerConfiguration" type="tns:simpleSchedulerConfig" minOccurs="0"
+                         maxOccurs="1"/>
             <xsd:element name="BpelUI" type="tns:tBpelUI" maxOccurs="1" minOccurs="0"/>
+            <xsd:element name="BpelDeploy" type="tns:tBpelDeploy" minOccurs="0" maxOccurs="1"/>
+
             <xsd:element name="TransactionManagerTimeout" type="xsd:int" minOccurs="0" maxOccurs="1"/>
         </xsd:sequence>
     </xsd:complexType>
@@ -281,6 +284,12 @@
                          minOccurs="0"/>
             <xsd:element name="InstanceViewVariableLength" type="xsd:int" minOccurs="0"
                          maxOccurs="1"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="tBpelDeploy">
+        <xsd:sequence>
+            <xsd:element name="DeployTimeOut" type="xsd:long" maxOccurs="1"
+                         minOccurs="0"/>
         </xsd:sequence>
     </xsd:complexType>
     <xsd:complexType name="tODESecondaryStaleNodeDetection">


### PR DESCRIPTION
## Purpose
Fixes the issue thrown when a bpel process is deployed in a slave node
prior to the master node by introducing the BpelDeploy property
where a timeout can be defined to check whether the process is
deployed in master node.

## Goals
Fixes https://github.com/wso2/product-ei/issues/3998## 