### PR TITLE
Fix Nullpointer exception when shutting down the IS server.

### DIFF
--- a/components/common/src/main/java/org/wso2/carbon/bpel/common/internal/BPELCommonServiceComponent.java
+++ b/components/common/src/main/java/org/wso2/carbon/bpel/common/internal/BPELCommonServiceComponent.java
@@ -37,8 +37,6 @@ public class BPELCommonServiceComponent {
 
     private BundleContext bundleContext;
 
-    private ServiceRegistration registration;
-
     @Activate
     protected void activate(ComponentContext ctxt) {
 
@@ -85,6 +83,5 @@ public class BPELCommonServiceComponent {
         if (log.isDebugEnabled()) {
             log.debug("Stopping the BPEL common Component");
         }
-        componentContext.getBundleContext().ungetService(registration.getReference());
     }
 }


### PR DESCRIPTION
## Purpose
> Fix Nullpointer exception when shutting down the IS server.

```
ERROR {org.wso2.carbon.bpel.common} - [SCR] Error while attempting to deactivate instance of component Component[
	name = org.wso2.carbon.bpel.common.internal.BPELCommonServiceComponent
	factory = null
	autoenable = true
	immediate = true
	implementation = org.wso2.carbon.bpel.common.internal.BPELCommonServiceComponent
	state = Unsatisfied
	properties =
	serviceFactory = false
	serviceInterface = null
	references = {
		Reference[name = registry.service, interface = org.wso2.carbon.registry.core.service.RegistryService, policy = dynamic, cardinality = 1..1, target = null, bind = setRegistryService, unbind = unsetRegistryService]
	}
	located in bundle = org.wso2.carbon.bpel.common_4.5.9 [193]
]
```

