### PR TITLE
Add default variable support for rest task for error handling

### DIFF
--- a/components/bpmn/org.wso2.carbon.bpmn.extensions/src/main/java/org/wso2/carbon/bpmn/extensions/rest/RESTTask.java
+++ b/components/bpmn/org.wso2.carbon.bpmn.extensions/src/main/java/org/wso2/carbon/bpmn/extensions/rest/RESTTask.java
@@ -21,6 +21,7 @@ import org.activiti.engine.delegate.JavaDelegate;
 import org.apache.axiom.om.OMElement;
 import org.apache.axiom.om.util.AXIOMUtil;
 import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.Header;
@@ -147,6 +148,7 @@ public class RESTTask implements JavaDelegate {
     private Expression responseHeaderVariable;
     private Expression httpStatusVariable;
     private Expression errorMessageVariable;
+    private Expression defaultVariableSetFlag;
 
     @Override
     public void execute(DelegateExecution execution) {
@@ -281,6 +283,11 @@ public class RESTTask implements JavaDelegate {
                 output = StringEscapeUtils.escapeXml(String.valueOf(output));
             }
 
+            boolean isDefaultVarAvailable = false;
+            if (defaultVariableSetFlag != null) {
+                isDefaultVarAvailable = Boolean.valueOf(defaultVariableSetFlag.getValue(execution).toString());
+            }
+
             if (outputVariable != null) {
                 String outVarName = outputVariable.getValue(execution).toString();
                 execution.setVariable(outVarName, output);
@@ -292,11 +299,37 @@ public class RESTTask implements JavaDelegate {
                     String[] mappingParts = mapping.split(":");
                     String varName = mappingParts[0];
                     String expression = mappingParts[1];
+                    String defaultVariableStr = null;
+                    if (mappingParts.length == 3) {
+                        defaultVariableStr = mappingParts[2];
+                    }
                     Object value;
                     if (output instanceof JsonNodeObject) {
-                        value = ((JsonNodeObject) output).jsonPath(expression);
+                        try {
+                            value = ((JsonNodeObject) output).jsonPath(expression);
+                        } catch (BPMNJsonException e) {
+                            if (isDefaultVarAvailable) {
+                                value = null;
+                                if (StringUtils.isNotBlank(defaultVariableStr)) {
+                                    value = execution.getVariable(defaultVariableStr);
+                                }
+                            } else {
+                                throw e;
+                            }
+                        }
                     } else if (output instanceof XMLDocument) {
-                        value = ((XMLDocument) output).xPath(expression);
+                        try {
+                            value = ((XMLDocument) output).xPath(expression);
+                        } catch (BPMNXmlException e) {
+                            if (isDefaultVarAvailable) {
+                                value = null;
+                                if (StringUtils.isNotBlank(defaultVariableStr)) {
+                                    value = execution.getVariable(defaultVariableStr);
+                                }
+                            } else {
+                                throw e;
+                            }
+                        }
                     } else {
                         String errorMessage = "Unrecognized content type found. " + "HTTP Status : " + response
                                 .getHttpStatus() + ", Response Content : " + output.toString();
@@ -425,4 +458,7 @@ public class RESTTask implements JavaDelegate {
         this.errorMessageVariable = errorMessageVariable;
     }
 
+    public void setDefaultVariableSetFlag(Expression defaultVariableSetFlag) {
+        this.defaultVariableSetFlag = defaultVariableSetFlag;
+    }
 }

--- a/components/bpmn/org.wso2.carbon.bpmn.extensions/src/main/java/org/wso2/carbon/bpmn/extensions/rest/RESTTask.java
+++ b/components/bpmn/org.wso2.carbon.bpmn.extensions/src/main/java/org/wso2/carbon/bpmn/extensions/rest/RESTTask.java
@@ -148,7 +148,7 @@ public class RESTTask implements JavaDelegate {
     private Expression responseHeaderVariable;
     private Expression httpStatusVariable;
     private Expression errorMessageVariable;
-    private Expression defaultVariableSetFlag;
+    private Expression enableDefaultVariable;
 
     @Override
     public void execute(DelegateExecution execution) {
@@ -284,8 +284,8 @@ public class RESTTask implements JavaDelegate {
             }
 
             boolean isDefaultVarAvailable = false;
-            if (defaultVariableSetFlag != null) {
-                isDefaultVarAvailable = Boolean.valueOf(defaultVariableSetFlag.getValue(execution).toString());
+            if (enableDefaultVariable != null) {
+                isDefaultVarAvailable = Boolean.valueOf(enableDefaultVariable.getValue(execution).toString());
             }
 
             if (outputVariable != null) {
@@ -458,7 +458,7 @@ public class RESTTask implements JavaDelegate {
         this.errorMessageVariable = errorMessageVariable;
     }
 
-    public void setDefaultVariableSetFlag(Expression defaultVariableSetFlag) {
-        this.defaultVariableSetFlag = defaultVariableSetFlag;
+    public void setEnableDefaultVariable(Expression enableDefaultVariable) {
+        this.enableDefaultVariable = enableDefaultVariable;
     }
 }

--- a/components/bpmn/org.wso2.carbon.bpmn/src/main/java/org/wso2/carbon/bpmn/core/types/datatypes/json/api/JsonNodeObject.java
+++ b/components/bpmn/org.wso2.carbon.bpmn/src/main/java/org/wso2/carbon/bpmn/core/types/datatypes/json/api/JsonNodeObject.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.bpmn.core.types.datatypes.json.api;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.PathNotFoundException;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.bpmn.core.types.datatypes.json.BPMNJsonException;
@@ -63,7 +64,12 @@ public class JsonNodeObject {
 
         ObjectMapper mapper = new ObjectMapper();
         Map map = mapper.convertValue(jsonNode, Map.class);
-        Object result = JsonPath.read(map, jsonPathStr);
+        Object result;
+        try {
+            result = JsonPath.read(map, jsonPathStr);
+        } catch (PathNotFoundException e) {
+            throw new BPMNJsonException("Error occurred while reading json path.", e);
+        }
 
         JsonBuilder builder = new JsonBuilder(mapper);
         if (result instanceof Map) {


### PR DESCRIPTION
## Purpose
> This PR will introduce a default variable to set for the rest task output mappings if any error response sent from the BE. In the following example if an error response is sent from the backend, then the json path evaluation fails hence it will set the value from the defaultVar for the status.
```xml
        <activiti:field name="outputMappings">
          <activiti:string>status:$.status:defaultVar</activiti:string>
        </activiti:field>
```
Fixes :https://github.com/wso2/product-ei/issues/4573