### PR TITLE
Remove dependency org.wso2.carbon.service.mgt from org.wso2.carbon.bpel module

### DIFF
--- a/components/bpel/org.wso2.carbon.bpel.ui/pom.xml
+++ b/components/bpel/org.wso2.carbon.bpel.ui/pom.xml
@@ -78,6 +78,10 @@
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.deployment</groupId>
+            <artifactId>org.wso2.carbon.service.mgt</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.deployment</groupId>
             <artifactId>org.wso2.carbon.service.mgt.ui</artifactId>
         </dependency>
         <dependency>

--- a/components/bpel/org.wso2.carbon.bpel/pom.xml
+++ b/components/bpel/org.wso2.carbon.bpel/pom.xml
@@ -126,10 +126,6 @@
             <artifactId>org.wso2.carbon.unifiedendpoint.core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.carbon.deployment</groupId>
-            <artifactId>org.wso2.carbon.service.mgt</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.wso2.carbon.business-process</groupId>
             <artifactId>org.wso2.carbon.bpel.skeleton</artifactId>
         </dependency>

--- a/components/bpel/org.wso2.carbon.bpel/src/main/java/org/wso2/carbon/bpel/core/ode/integration/mgt/services/ProcessManagementServiceSkeleton.java
+++ b/components/bpel/org.wso2.carbon.bpel/src/main/java/org/wso2/carbon/bpel/core/ode/integration/mgt/services/ProcessManagementServiceSkeleton.java
@@ -21,6 +21,10 @@ import org.apache.axiom.om.OMElement;
 import org.apache.axiom.om.OMFactory;
 import org.apache.axiom.om.impl.builder.StAXOMBuilder;
 import org.apache.axis2.AxisFault;
+import org.apache.axis2.addressing.EndpointReference;
+import org.apache.axis2.context.ConfigurationContext;
+import org.apache.axis2.description.TransportInDescription;
+import org.apache.axis2.engine.AxisConfiguration;
 import org.apache.commons.collections.comparators.ComparatorChain;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -89,12 +93,15 @@ import org.wso2.carbon.bpel.skeleton.ode.integration.mgt.services.types.ServiceL
 import org.wso2.carbon.bpel.skeleton.ode.integration.mgt.services.types.Service_type0;
 import org.wso2.carbon.bpel.skeleton.ode.integration.mgt.services.types.Service_type1;
 import org.wso2.carbon.core.AbstractAdmin;
-import org.wso2.carbon.service.mgt.util.Utils;
+import org.wso2.carbon.core.transports.http.HttpTransportListener;
+import org.wso2.carbon.utils.CarbonUtils;
+import org.wso2.carbon.utils.NetworkUtils;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.net.SocketException;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -116,6 +123,9 @@ import javax.xml.stream.XMLStreamReader;
  */
 public class ProcessManagementServiceSkeleton extends AbstractAdmin
         implements ProcessManagementServiceSkeletonInterface {
+
+    private static boolean isServletTransport = false;
+    private static boolean isServletTransportSet = false;
     private static Log log = LogFactory.getLog(ProcessManagementServiceSkeleton.class);
     private BPELServerImpl bpelServer = BPELServerImpl.getInstance();
     private BpelDatabase bpelDb = bpelServer.getODEBPELServer().getBpelDb();
@@ -505,9 +515,9 @@ public class ProcessManagementServiceSkeleton extends AbstractAdmin
                 eprType.setService(serviceName);
                 ServiceLocation sLocation = new ServiceLocation();
                 try {
-                    String url = Utils.getTryitURL(serviceName.getLocalPart(), getConfigContext());
+                    String url = getTryitURL(serviceName.getLocalPart(), getConfigContext());
                     sLocation.addServiceLocation(url);
-                    String[] wsdls = Utils.getWsdlInformation(serviceName.getLocalPart(),
+                    String[] wsdls = getWsdlInformation(serviceName.getLocalPart(),
                             getConfigContext().getAxisConfiguration());
                     if (wsdls.length == 2) {
                         if (wsdls[0].endsWith("?wsdl")) {
@@ -917,5 +927,70 @@ public class ProcessManagementServiceSkeleton extends AbstractAdmin
         String errMsg = "Process Definition for: " + pConf.getProcessId() + " not found";
         log.error(errMsg);
         throw new ProcessManagementException(errMsg);
+    }
+
+    private static String getTryitURL(String serviceName, ConfigurationContext configurationContext) throws AxisFault {
+        AxisConfiguration axisConfig = configurationContext.getAxisConfiguration();
+        String wsdlURL = getWsdlInformation(serviceName, axisConfig)[0];
+        String tryitPrefix = wsdlURL.substring(0, wsdlURL.length() - serviceName.length() - 5);
+        if (!isServletTransport(axisConfig)) {
+            int tenantIndex = tryitPrefix.indexOf("/t/");
+            if (tenantIndex != -1) {
+                String tmpTryitPrefix = tryitPrefix.substring(tryitPrefix.substring(0, tryitPrefix.indexOf("/t/")).lastIndexOf("/"));
+                tryitPrefix = tryitPrefix.replaceFirst("//", "");
+                if (tryitPrefix.substring(0, tryitPrefix.indexOf("/services/")).lastIndexOf("/") > -1) {
+                    tryitPrefix = tryitPrefix.substring(tryitPrefix.substring(0, tryitPrefix.indexOf("/services/")).lastIndexOf("/"));
+                } else {
+                    tryitPrefix = tmpTryitPrefix;
+                }
+            } else {
+                tryitPrefix = configurationContext.getServiceContextPath() + "/";
+            }
+        }
+
+        return CarbonUtils.getProxyContextPath(false) + tryitPrefix + serviceName + "?tryit";
+    }
+
+    private static String[] getWsdlInformation(String serviceName, AxisConfiguration axisConfig) throws AxisFault {
+        String ip;
+        try {
+            ip = NetworkUtils.getLocalHostname();
+        } catch (SocketException var6) {
+            throw new AxisFault("Cannot get local host name", var6);
+        }
+
+        TransportInDescription transportInDescription = axisConfig.getTransportIn("http");
+        if (transportInDescription == null) {
+            transportInDescription = axisConfig.getTransportIn("https");
+        }
+
+        if (transportInDescription != null) {
+            EndpointReference[] epr = transportInDescription.getReceiver().getEPRsForService(serviceName, ip);
+            String wsdlUrlPrefix = epr[0].getAddress();
+            if (wsdlUrlPrefix.endsWith("/")) {
+                wsdlUrlPrefix = wsdlUrlPrefix.substring(0, wsdlUrlPrefix.length() - 1);
+            }
+
+            return new String[]{wsdlUrlPrefix + "?wsdl", wsdlUrlPrefix + "?wsdl2"};
+        } else {
+            return new String[0];
+        }
+    }
+
+    private static boolean isServletTransport(AxisConfiguration axisConfig) {
+        if (!isServletTransportSet) {
+            TransportInDescription transportInDescription = axisConfig.getTransportIn("http");
+            if (transportInDescription == null) {
+                transportInDescription = axisConfig.getTransportIn("https");
+            }
+
+            if (transportInDescription != null && transportInDescription.getReceiver() instanceof HttpTransportListener) {
+                isServletTransport = true;
+            }
+
+            isServletTransportSet = true;
+        }
+
+        return isServletTransport;
     }
 }

--- a/features/bpel/org.wso2.carbon.bpel.server.feature/pom.xml
+++ b/features/bpel/org.wso2.carbon.bpel.server.feature/pom.xml
@@ -247,9 +247,6 @@
                                     org.wso2.carbon.core.server:compatible:${carbon.kernel.feature.version}
                                 </importFeatureDef>
                                 <importFeatureDef>
-                                    org.wso2.carbon.service.mgt.server:compatible:${carbon.deployment.version}
-                                </importFeatureDef>
-                                <importFeatureDef>
                                     org.wso2.carbon.unifiedendpoint.server:compatible:${carbon.business-process.version}
                                 </importFeatureDef>
                                 <importFeatureDef>

--- a/features/bpel/org.wso2.carbon.bpel.ui.feature/pom.xml
+++ b/features/bpel/org.wso2.carbon.bpel.ui.feature/pom.xml
@@ -133,6 +133,9 @@
                                 <importFeatureDef>org.wso2.carbon.core.ui:compatible:${carbon.kernel.feature.version}
                                 </importFeatureDef>
                                 <importFeatureDef>
+                                    org.wso2.carbon.service.mgt.server:compatible:${carbon.deployment.version}
+                                </importFeatureDef>
+                                <importFeatureDef>
                                     org.wso2.carbon.service.mgt.ui:compatible:${carbon.deployment.version}
                                 </importFeatureDef>
                                 <importFeatureDef>org.wso2.carbon.tryit:compatible:${carbon.commons.version}

--- a/features/humantask/org.wso2.carbon.humantask.server.feature/pom.xml
+++ b/features/humantask/org.wso2.carbon.humantask.server.feature/pom.xml
@@ -229,9 +229,6 @@
                                     org.wso2.carbon.core.server:compatible:${carbon.kernel.feature.version}
                                 </importFeatureDef>
                                 <importFeatureDef>
-                                    org.wso2.carbon.service.mgt.server:compatible:${carbon.deployment.version}
-                                </importFeatureDef>
-                                <importFeatureDef>
                                     org.wso2.carbon.system.statistics.server:compatible:${carbon.commons.version}
                                 </importFeatureDef>
                                 <importFeatureDef>


### PR DESCRIPTION
To get rid of org.wso2.carbon.service.mgt and org.wso2.carbon.module.mgt components from Identity Server distribution we had to do below changes[1] in the carbon-business-process[2]:

- The class ProcessManagementServiceSkeleton[3] was using class[4] from org.wso2.carbon.service.mgt[5] module of carbon-deployment[6] so we copied the required util methods into that class itself and removed the dependency for org.wso2.carbon.service.mgt component.
-  Moved the importFeatureDef for org.wso2.carbon.service.mgt.server from org.wso2.carbon.bpel.server.feature[7] to org.wso2.carbon.bpel.ui.feature[8].
- Removed the importFeatureDef for org.wso2.carbon.service.mgt.server from org.wso2.carbon.humantask.server.feature[9] since it only has imports for ui and stubs and does not have imports for org.wso2.carbon.service.mgt[5].

[1] - https://github.com/deshankoswatte/carbon-business-process
[2] - https://github.com/wso2/carbon-business-process
[3] - https://github.com/wso2/carbon-business-process/blob/master/components/bpel/org.wso2.carbon.bpel/src/main/java/org/wso2/carbon/bpel/core/ode/integration/mgt/services/ProcessManagementServiceSkeleton.java
[4] - https://github.com/wso2/carbon-deployment/blob/4.10.x/components/service-mgt/axis2-service-mgt/org.wso2.carbon.service.mgt/src/main/java/org/wso2/carbon/service/mgt/util/Utils.java
[5] - https://github.com/wso2/carbon-deployment/tree/4.10.x/components/service-mgt/axis2-service-mgt/org.wso2.carbon.service.mgt/
[6] - https://github.com/wso2/carbon-deployment/tree/4.10.x
[7] - https://github.com/wso2/carbon-business-process/tree/master/features/bpel/org.wso2.carbon.bpel.server.feature
[8] - https://github.com/wso2/carbon-business-process/tree/master/features/bpel/org.wso2.carbon.bpel.ui.feature
[9] - https://github.com/wso2/carbon-business-process/tree/master/features/humantask/org.wso2.carbon.humantask.server.feature
