### PR TITLE
Fix EI-5150 BPEL Process Visualization is not loading with OpenJDK 8

### DIFF
--- a/components/bpel/org.wso2.carbon.bpel.ui/src/main/java/org/wso2/carbon/bpel/ui/bpel2svg/impl/ActivityImpl.java
+++ b/components/bpel/org.wso2.carbon.bpel.ui/src/main/java/org/wso2/carbon/bpel/ui/bpel2svg/impl/ActivityImpl.java
@@ -18,7 +18,7 @@ package org.wso2.carbon.bpel.ui.bpel2svg.impl;
 
 import org.apache.axiom.om.OMAttribute;
 import org.apache.axiom.om.OMElement;
-import org.apache.batik.dom.svg.SVGDOMImplementation;
+import org.apache.batik.anim.dom.SVGDOMImplementation;
 import org.apache.batik.svggen.SVGGraphics2D;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/pom.xml
+++ b/pom.xml
@@ -1592,7 +1592,7 @@
         <!--  <org.eclipse.osgi.version>3.5.0.v20090520</org.eclipse.osgi.version>-->
         <org.eclipse.osgi.version>3.9.1.v20130814-1242</org.eclipse.osgi.version>
         <!--simple-json.version>1.1</simple-json.version-->
-        <batik.version>1.7.0.wso2v1</batik.version>
+        <batik.version>1.9.1.wso2v1</batik.version>
         <!--<synapse.version>2.1.3-wso2v1</synapse.version>-->
         <saxon-he.wso2.version>9.4.0.wso2v1</saxon-he.wso2.version>
         <orbit.version.commons.dbcp>1.4.0.wso2v1</orbit.version.commons.dbcp>


### PR DESCRIPTION

## Purpose
This is to fix wso2/product-ei#5150
The Apache Batik version is upgraded to 1.9.1