### PR TITLE
Remove spring 3 framework.

### DIFF
--- a/features/bpel/org.wso2.carbon.bpel.server.feature/pom.xml
+++ b/features/bpel/org.wso2.carbon.bpel.server.feature/pom.xml
@@ -236,9 +236,6 @@
                                 <importBundleDef>antlr.wso2:antlr</importBundleDef>
                                 <importBundleDef>rhino.wso2:js</importBundleDef>
                                 <importBundleDef>
-                                    org.springframework.ws.wso2:spring.framework:${orbit.version.spring}
-                                </importBundleDef>
-                                <importBundleDef>
                                     org.wso2.carbon.business-process:org.wso2.carbon.bpel.common
                                 </importBundleDef>
                             </importBundles>

--- a/features/bpel/pom.xml
+++ b/features/bpel/pom.xml
@@ -203,10 +203,6 @@
                 <artifactId>json-simple</artifactId>
             </dependency>
             <dependency>
-                <groupId>org.springframework.ws.wso2</groupId>
-                <artifactId>spring.framework</artifactId>
-            </dependency>
-            <dependency>
                 <groupId>org.wso2.carbon.commons</groupId>
                 <artifactId>org.wso2.carbon.statistics.ui</artifactId>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -321,12 +321,6 @@
                 <artifactId>json-simple</artifactId>
                 <version>${simple-json.version}</version>
             </dependency>
-            <!-- Feature related dependencies -->
-            <dependency>
-                <groupId>org.springframework.ws.wso2</groupId>
-                <artifactId>spring.framework</artifactId>
-                <version>${orbit.version.spring}</version>
-            </dependency>
 
             <!--CXF runtime environment-->
             <dependency>


### PR DESCRIPTION
## Purpose
The spring framework should not be available in the OSGi runtime. It is available in the lib/runtimes and added to the web applications.

