### PR TITLE
Remove spring 3 framework from OSGi

### DIFF
--- a/features/bpel/org.wso2.carbon.bpel.server.feature/pom.xml
+++ b/features/bpel/org.wso2.carbon.bpel.server.feature/pom.xml
@@ -236,9 +236,6 @@
                                 <importBundleDef>antlr.wso2:antlr</importBundleDef>
                                 <importBundleDef>rhino.wso2:js</importBundleDef>
                                 <importBundleDef>
-                                    org.springframework.ws.wso2:spring.framework:${orbit.version.spring}
-                                </importBundleDef>
-                                <importBundleDef>
                                     org.wso2.carbon.business-process:org.wso2.carbon.bpel.common
                                 </importBundleDef>
                             </importBundles>

--- a/features/bpel/pom.xml
+++ b/features/bpel/pom.xml
@@ -203,10 +203,6 @@
                 <artifactId>json-simple</artifactId>
             </dependency>
             <dependency>
-                <groupId>org.springframework.ws.wso2</groupId>
-                <artifactId>spring.framework</artifactId>
-            </dependency>
-            <dependency>
                 <groupId>org.wso2.carbon.commons</groupId>
                 <artifactId>org.wso2.carbon.statistics.ui</artifactId>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -321,12 +321,6 @@
                 <artifactId>json-simple</artifactId>
                 <version>${simple-json.version}</version>
             </dependency>
-            <!-- Feature related dependencies -->
-            <dependency>
-                <groupId>org.springframework.ws.wso2</groupId>
-                <artifactId>spring.framework</artifactId>
-                <version>${orbit.version.spring}</version>
-            </dependency>
 
             <!--CXF runtime environment-->
             <dependency>
@@ -1523,7 +1517,6 @@
         <geronimo-spec-jms>1.1.0.rc4-wso2v1</geronimo-spec-jms>
         <orbit.version.infinispan>5.1.2.wso2v1</orbit.version.infinispan>
         <orbit.version.h2.engine>1.4.199.wso2v1</orbit.version.h2.engine>
-        <orbit.version.spring>3.2.9.wso2v2</orbit.version.spring>
         <orbit.version.woden>1.0.0.M9-wso2v1</orbit.version.woden>
         <axion.wso2>1.0.0.M3-dev-wso2v1</axion.wso2>
         <tranql-connector>1.8.wso2v1</tranql-connector>
@@ -1601,7 +1594,7 @@
         <!--geronimo-ejb_2.1_spec.version>1.1.0.wso2v1</geronimo-ejb_2.1_spec.version-->
         <derby.wso2.version>10.3.2.1wso2v1</derby.wso2.version>
         <version.javax.servlet>3.0.0.v201112011016</version.javax.servlet>
-        <orbit.ode.version>1.3.5-wso2v20</orbit.ode.version>
+        <orbit.ode.version>1.3.5-wso2v21</orbit.ode.version>
         <mybatis.version>3.2.5</mybatis.version>
         <joda.time.version>2.9.4.wso2v1</joda.time.version>
         <snakeyaml.version>1.23</snakeyaml.version>


### PR DESCRIPTION
The spring framework should not be available in the OSGi runtime. It is available in the lib/runtimes and added as an embedded dependency for ode
