### PR TITLE
Update third party dependencies

### DIFF
--- a/features/bpel/org.wso2.carbon.bpel.server.feature/pom.xml
+++ b/features/bpel/org.wso2.carbon.bpel.server.feature/pom.xml
@@ -201,6 +201,8 @@
                             <importBundles>
                                 <importBundleDef>org.wso2.orbit.org.apache.ode:ode</importBundleDef>
                                 <importBundleDef>org.ow2.asm:asm</importBundleDef>
+                                <importBundleDef>org.ow2.asm:asm-commons</importBundleDef>
+                                <importBundleDef>org.ow2.asm:asm-tree</importBundleDef>
                                 <importBundleDef>cglib.wso2:cglib</importBundleDef>
                                 <!--importBundleDef>org.apache.axis2.wso2:axis2-jibx</importBundleDef-->
                                 <importBundleDef>org.jibx.wso2:jibx</importBundleDef>

--- a/features/bpel/org.wso2.carbon.bpel.server.feature/pom.xml
+++ b/features/bpel/org.wso2.carbon.bpel.server.feature/pom.xml
@@ -200,7 +200,7 @@
                             </bundles>
                             <importBundles>
                                 <importBundleDef>org.wso2.orbit.org.apache.ode:ode</importBundleDef>
-                                <importBundleDef>org.ow2.asm:asm-all</importBundleDef>
+                                <importBundleDef>org.ow2.asm:asm</importBundleDef>
                                 <importBundleDef>cglib.wso2:cglib</importBundleDef>
                                 <!--importBundleDef>org.apache.axis2.wso2:axis2-jibx</importBundleDef-->
                                 <importBundleDef>org.jibx.wso2:jibx</importBundleDef>

--- a/features/bpel/org.wso2.carbon.bpel.ui.feature/pom.xml
+++ b/features/bpel/org.wso2.carbon.bpel.ui.feature/pom.xml
@@ -92,7 +92,7 @@
                             </bundles>
                             <importBundles>
                                 <importBundleDef>org.wso2.orbit.org.apache.ode:ode</importBundleDef>
-                                <importBundleDef>org.ow2.asm:asm-all</importBundleDef>
+                                <importBundleDef>org.ow2.asm:asm</importBundleDef>
                                 <importBundleDef>cglib.wso2:cglib</importBundleDef>
                                 <!--importBundleDef>org.apache.axis2.wso2:axis2-jibx</importBundleDef-->
                                 <importBundleDef>org.jibx.wso2:jibx</importBundleDef>

--- a/features/bpel/pom.xml
+++ b/features/bpel/pom.xml
@@ -164,7 +164,7 @@
             </dependency>
             <dependency>
                 <groupId>org.ow2.asm</groupId>
-                <artifactId>asm-all</artifactId>
+                <artifactId>asm</artifactId>
             </dependency>
             <dependency>
                 <groupId>cglib.wso2</groupId>

--- a/features/bpel/pom.xml
+++ b/features/bpel/pom.xml
@@ -167,6 +167,14 @@
                 <artifactId>asm</artifactId>
             </dependency>
             <dependency>
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm-commons</artifactId>
+            </dependency>
+            <dependency>
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm-tree</artifactId>
+            </dependency>
+            <dependency>
                 <groupId>cglib.wso2</groupId>
                 <artifactId>cglib</artifactId>
             </dependency>

--- a/features/bpmn/org.wso2.carbon.bpmn.server.feature/pom.xml
+++ b/features/bpmn/org.wso2.carbon.bpmn.server.feature/pom.xml
@@ -185,7 +185,7 @@
                                 <importBundleDef>org.wso2.orbit.com.jayway.jsonpath:json-path:${jsonpath.wso2.version}</importBundleDef>
                                 <importBundleDef>net.minidev:json-smart:${json.smart.version}</importBundleDef>
                                 <importBundleDef>net.minidev:accessors-smart:${accessors-smart.version}</importBundleDef>
-                                <importBundleDef>org.ow2.asm:asm-all:${org.ow2.asm.asm-all.version}</importBundleDef>
+                                <importBundleDef>org.ow2.asm:asm:${org.ow2.asm.version}</importBundleDef>
 
                             </importBundles>
 

--- a/features/humantask/org.wso2.carbon.humantask.server.feature/pom.xml
+++ b/features/humantask/org.wso2.carbon.humantask.server.feature/pom.xml
@@ -221,7 +221,7 @@
                                 <importBundleDef>net.sourceforge.serp.wso2:serp</importBundleDef>
                                 <!--For HT Rendering-->
                                 <importBundleDef>org.wso2.orbit.com.predic8:soa.model.core:${com.predic8.soa-model-core.wso2.version}</importBundleDef>
-                                <importBundleDef>org.ow2.asm:asm-all:${org.ow2.asm.asm-all.version}</importBundleDef>
+                                <importBundleDef>org.ow2.asm:asm:${org.ow2.asm.version}</importBundleDef>
                                 <importBundleDef>org.codehaus.groovy:groovy-all:${org.codehaus.groovy.version}</importBundleDef>
                             </importBundles>
                             <importFeatures>

--- a/pom.xml
+++ b/pom.xml
@@ -1081,6 +1081,18 @@
             </dependency>
 
             <dependency>
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm-commons</artifactId>
+                <version>${org.ow2.asm.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm-tree</artifactId>
+                <version>${org.ow2.asm.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>org.codehaus.groovy</groupId>
                 <artifactId>groovy-all</artifactId>
                 <version>${org.codehaus.groovy.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -1076,8 +1076,8 @@
 
             <dependency>
                 <groupId>org.ow2.asm</groupId>
-                <artifactId>asm-all</artifactId>
-                <version>${org.ow2.asm.asm-all.version}</version>
+                <artifactId>asm</artifactId>
+                <version>${org.ow2.asm.version}</version>
             </dependency>
 
             <dependency>
@@ -1604,7 +1604,7 @@
         <jsonpath.wso2.version>2.4.0.wso2v2</jsonpath.wso2.version>
         <json.smart.version>2.3</json.smart.version>
         <accessors-smart.version>1.2</accessors-smart.version>
-        <org.ow2.asm.asm-all.version>5.2</org.ow2.asm.asm-all.version>
+        <org.ow2.asm.version>9.2</org.ow2.asm.version>
 
 
         <!-- Servlet API -->


### PR DESCRIPTION
## Purpose
Update third party dependencies
Related to https://github.com/wso2/product-is/issues/12479

When we update asm library we need to add asm-commons, asm-tree as seperate dependencies since latest asm doesn't contain these packages inside asm.