### PR TITLE
Upgrade h2 database engine version to 2.1.210

### DIFF
--- a/components/attachment-mgt/org.wso2.carbon.attachment.mgt/pom.xml
+++ b/components/attachment-mgt/org.wso2.carbon.attachment.mgt/pom.xml
@@ -138,7 +138,7 @@
                                     <path refid="maven.test.classpath" />
                                 </path>
                                 <echo message="########### Create Test Database ##############" />
-                                <sql autocommit="true" driver="org.h2.Driver" onerror="continue" password="wso2carbon" url="jdbc:h2:${basedir}/target/repository/database/attachmentdb;create=true" userid="wso2carbon">
+                                <sql autocommit="true" driver="org.h2.Driver" onerror="continue" password="wso2carbon" url="jdbc:h2:${basedir}/target/repository/database/attachmentdb" userid="wso2carbon">
                                     <classpath>
                                         <path refid="h2.classpath" />
                                     </classpath>

--- a/components/bpel/org.wso2.carbon.bpel.b4p/pom.xml
+++ b/components/bpel/org.wso2.carbon.bpel.b4p/pom.xml
@@ -166,7 +166,7 @@
                                 </path>
 
                                 <echo message="########### Create B4P Coordination Database ##############" />
-                                <sql autocommit="true" driver="org.h2.Driver" onerror="continue" password="" url="jdbc:h2:${basedir}/target/database/b4ph2db;create=true" userid="sa">
+                                <sql autocommit="true" driver="org.h2.Driver" onerror="continue" password="" url="jdbc:h2:${basedir}/target/database/b4ph2db" userid="sa">
                                     <classpath>
                                         <path refid="h2.classpath" />
                                     </classpath>

--- a/components/humantask/org.wso2.carbon.humantask/pom.xml
+++ b/components/humantask/org.wso2.carbon.humantask/pom.xml
@@ -150,7 +150,7 @@
                                 </path>
 
                                 <echo message="########### Create HT Database ##############" />
-                                <sql autocommit="true" driver="org.h2.Driver" onerror="continue" password="" url="jdbc:h2:${basedir}/target/database/hth2db;create=true" userid="sa">
+                                <sql autocommit="true" driver="org.h2.Driver" onerror="continue" password="" url="jdbc:h2:${basedir}/target/database/hth2db" userid="sa">
                                     <classpath>
                                         <path refid="h2.classpath" />
                                     </classpath>

--- a/features/attachment-mgt/org.wso2.carbon.attachment.mgt.server.feature/pom.xml
+++ b/features/attachment-mgt/org.wso2.carbon.attachment.mgt.server.feature/pom.xml
@@ -65,7 +65,7 @@
 
                                 <echo message="########### Create Attachment Mgt Database ##############" />
 
-                                <sql driver="org.h2.Driver" url="jdbc:h2:${basedir}/resources/conf/jpadb;create=true" userid="wso2carbon" password="wso2carbon" autocommit="true" onerror="continue">
+                                <sql driver="org.h2.Driver" url="jdbc:h2:${basedir}/resources/conf/jpadb" userid="wso2carbon" password="wso2carbon" autocommit="true" onerror="continue">
                                     <classpath>
                                         <path refid="h2.classpath" />
                                     </classpath>

--- a/features/attachment-mgt/org.wso2.carbon.attachment.mgt.server.feature/resources/conf/bps-datasources.xml
+++ b/features/attachment-mgt/org.wso2.carbon.attachment.mgt.server.feature/resources/conf/bps-datasources.xml
@@ -13,7 +13,7 @@
             </jndiConfig>
             <definition type="RDBMS">
                 <configuration>
-                    <url>jdbc:h2:file:./repository/database/jpadb;DB_CLOSE_ON_EXIT=FALSE;MVCC=TRUE</url>
+                    <url>jdbc:h2:file:./repository/database/jpadb;DB_CLOSE_ON_EXIT=FALSE</url>
                     <username>wso2carbon</username>
                     <password>wso2carbon</password>
                     <driverClassName>org.h2.Driver</driverClassName>

--- a/features/attachment-mgt/org.wso2.carbon.attachment.mgt.server.feature/resources/conf/datasources.properties
+++ b/features/attachment-mgt/org.wso2.carbon.attachment.mgt.server.feature/resources/conf/datasources.properties
@@ -7,7 +7,7 @@ synapse.datasources.providerPort=2199
 synapse.datasources.bpsds.registry=JNDI
 synapse.datasources.bpsds.type=BasicDataSource
 synapse.datasources.bpsds.driverClassName=org.h2.Driver
-synapse.datasources.bpsds.url=jdbc:h2:file:./repository/database/jpadb;MVCC=TRUE
+synapse.datasources.bpsds.url=jdbc:h2:file:./repository/database/jpadb
 synapse.datasources.bpsds.username=wso2carbon
 synapse.datasources.bpsds.password=wso2carbon
 synapse.datasources.bpsds.validationQuery=SELECT 1

--- a/features/bpel/org.wso2.carbon.bpel.server.feature/pom.xml
+++ b/features/bpel/org.wso2.carbon.bpel.server.feature/pom.xml
@@ -102,7 +102,7 @@
 
                                 <echo message="########### Create BPEL Database ##############" />
 
-                                <sql driver="org.h2.Driver" url="jdbc:h2:${basedir}/resources/conf/jpadb;create=true" userid="wso2carbon" password="wso2carbon" autocommit="true" onerror="continue">
+                                <sql driver="org.h2.Driver" url="jdbc:h2:${basedir}/resources/conf/jpadb" userid="wso2carbon" password="wso2carbon" autocommit="true" onerror="continue">
                                     <classpath>
                                         <path refid="h2.classpath" />
                                     </classpath>

--- a/features/bpel/org.wso2.carbon.bpel.server.feature/resources/conf/bps-datasources.xml
+++ b/features/bpel/org.wso2.carbon.bpel.server.feature/resources/conf/bps-datasources.xml
@@ -13,7 +13,7 @@
             </jndiConfig>
             <definition type="RDBMS">
                 <configuration>
-                    <url>jdbc:h2:file:./repository/database/jpadb;DB_CLOSE_ON_EXIT=FALSE;MVCC=TRUE</url>
+                    <url>jdbc:h2:file:./repository/database/jpadb;DB_CLOSE_ON_EXIT=FALSE</url>
                     <username>wso2carbon</username>
                     <password>wso2carbon</password>
                     <driverClassName>org.h2.Driver</driverClassName>

--- a/features/bpel/org.wso2.carbon.bpel.server.feature/resources/conf/datasources.properties
+++ b/features/bpel/org.wso2.carbon.bpel.server.feature/resources/conf/datasources.properties
@@ -7,7 +7,7 @@ synapse.datasources.providerPort=2199
 synapse.datasources.bpsds.registry=JNDI
 synapse.datasources.bpsds.type=BasicDataSource
 synapse.datasources.bpsds.driverClassName=org.h2.Driver
-synapse.datasources.bpsds.url=jdbc:h2:file:./repository/database/jpadb;MVCC=TRUE
+synapse.datasources.bpsds.url=jdbc:h2:file:./repository/database/jpadb
 synapse.datasources.bpsds.username=wso2carbon
 synapse.datasources.bpsds.password=wso2carbon
 synapse.datasources.bpsds.validationQuery=SELECT 1

--- a/features/bpmn/org.wso2.carbon.bpmn.server.feature/pom.xml
+++ b/features/bpmn/org.wso2.carbon.bpmn.server.feature/pom.xml
@@ -75,7 +75,7 @@
 
                                 <echo message="########### Create Activiti Database ##############" />
 
-                                <sql driver="org.h2.Driver" url="jdbc:h2:${basedir}/resources/conf/activiti;create=true" userid="wso2carbon" password="wso2carbon" autocommit="true" onerror="continue">
+                                <sql driver="org.h2.Driver" url="jdbc:h2:${basedir}/resources/conf/activiti" userid="wso2carbon" password="wso2carbon" autocommit="true" onerror="continue">
                                     <classpath>
                                         <path refid="h2.classpath" />
                                     </classpath>

--- a/features/humantask/org.wso2.carbon.humantask.server.feature/pom.xml
+++ b/features/humantask/org.wso2.carbon.humantask.server.feature/pom.xml
@@ -97,7 +97,7 @@
 
                                 <echo message="########### Create HumanTask Database ##############" />
 
-                                <sql driver="org.h2.Driver" url="jdbc:h2:${basedir}/resources/conf/jpadb;create=true" userid="wso2carbon" password="wso2carbon" autocommit="true" onerror="continue">
+                                <sql driver="org.h2.Driver" url="jdbc:h2:${basedir}/resources/conf/jpadb" userid="wso2carbon" password="wso2carbon" autocommit="true" onerror="continue">
                                     <classpath>
                                         <path refid="h2.classpath" />
                                     </classpath>

--- a/features/humantask/org.wso2.carbon.humantask.server.feature/resources/conf/bps-datasources.xml
+++ b/features/humantask/org.wso2.carbon.humantask.server.feature/resources/conf/bps-datasources.xml
@@ -13,7 +13,7 @@
             </jndiConfig>
             <definition type="RDBMS">
                 <configuration>
-                    <url>jdbc:h2:file:./repository/database/jpadb;DB_CLOSE_ON_EXIT=FALSE;MVCC=TRUE</url>
+                    <url>jdbc:h2:file:./repository/database/jpadb;DB_CLOSE_ON_EXIT=FALSE</url>
                     <username>wso2carbon</username>
                     <password>wso2carbon</password>
                     <driverClassName>org.h2.Driver</driverClassName>

--- a/features/humantask/org.wso2.carbon.humantask.server.feature/resources/conf/datasources.properties
+++ b/features/humantask/org.wso2.carbon.humantask.server.feature/resources/conf/datasources.properties
@@ -7,7 +7,7 @@ synapse.datasources.providerPort=2199
 synapse.datasources.bpsds.registry=JNDI
 synapse.datasources.bpsds.type=BasicDataSource
 synapse.datasources.bpsds.driverClassName=org.h2.Driver
-synapse.datasources.bpsds.url=jdbc:h2:file:./repository/database/jpadb;MVCC=TRUE
+synapse.datasources.bpsds.url=jdbc:h2:file:./repository/database/jpadb
 synapse.datasources.bpsds.username=wso2carbon
 synapse.datasources.bpsds.password=wso2carbon
 synapse.datasources.bpsds.validationQuery=SELECT 1

--- a/features/humantask/org.wso2.carbon.humantask.server.feature/resources/conf/org.wso2.carbon.humantask.server.feature.default.json
+++ b/features/humantask/org.wso2.carbon.humantask.server.feature/resources/conf/org.wso2.carbon.humantask.server.feature.default.json
@@ -1,5 +1,5 @@
 {
-  "bps_database.config.url" : "jdbc:h2:file:./repository/database/jpadb;DB_CLOSE_ON_EXIT=FALSE;MVCC=TRUE",
+  "bps_database.config.url" : "jdbc:h2:file:./repository/database/jpadb;DB_CLOSE_ON_EXIT=FALSE",
   "bps_database.config.username" : "wso2carbon",
   "bps_database.config.password" : "wso2carbon",
   "bps_database.config.driver" : "org.h2.Driver"

--- a/pom.xml
+++ b/pom.xml
@@ -1528,7 +1528,7 @@
         <geronimo-spec-javamail>1.3.0.rc51-wso2v1</geronimo-spec-javamail>
         <geronimo-spec-jms>1.1.0.rc4-wso2v1</geronimo-spec-jms>
         <orbit.version.infinispan>5.1.2.wso2v1</orbit.version.infinispan>
-        <orbit.version.h2.engine>1.4.199.wso2v1</orbit.version.h2.engine>
+        <orbit.version.h2.engine>2.0.206.wso2v1</orbit.version.h2.engine>
         <orbit.version.woden>1.0.0.M9-wso2v1</orbit.version.woden>
         <axion.wso2>1.0.0.M3-dev-wso2v1</axion.wso2>
         <tranql-connector>1.8.wso2v1</tranql-connector>

--- a/pom.xml
+++ b/pom.xml
@@ -1528,7 +1528,7 @@
         <geronimo-spec-javamail>1.3.0.rc51-wso2v1</geronimo-spec-javamail>
         <geronimo-spec-jms>1.1.0.rc4-wso2v1</geronimo-spec-jms>
         <orbit.version.infinispan>5.1.2.wso2v1</orbit.version.infinispan>
-        <orbit.version.h2.engine>2.0.206.wso2v1</orbit.version.h2.engine>
+        <orbit.version.h2.engine>2.1.210.wso2v1</orbit.version.h2.engine>
         <orbit.version.woden>1.0.0.M9-wso2v1</orbit.version.woden>
         <axion.wso2>1.0.0.M3-dev-wso2v1</axion.wso2>
         <tranql-connector>1.8.wso2v1</tranql-connector>


### PR DESCRIPTION
## Purpose

- Upgraded the h2 database engine version from 1.4.199.wso2v1 to 2.1.210.wso2v1. 
- Removed MVCC support setting as per their release notes([https://github.com/h2database/h2database/issues/2198#issuecomment-545003114](https://github.com/h2database/h2database/issues/2198#issuecomment-545003114)).

This should be merged after merging the  PR https://github.com/wso2/orbit/pull/537