### PR TITLE
Upgrade H2 DB version and Remove H2 Console

### DIFF
--- a/components/attachment-mgt/org.wso2.carbon.attachment.mgt/pom.xml
+++ b/components/attachment-mgt/org.wso2.carbon.attachment.mgt/pom.xml
@@ -77,7 +77,7 @@
         </dependency>
         <dependency>
             <groupId>org.wso2.orbit.com.h2database</groupId>
-            <artifactId>h2</artifactId>
+            <artifactId>h2-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -138,7 +138,7 @@
                                     <path refid="maven.test.classpath" />
                                 </path>
                                 <echo message="########### Create Test Database ##############" />
-                                <sql autocommit="true" driver="org.h2.Driver" onerror="continue" password="wso2carbon" url="jdbc:h2:${basedir}/target/repository/database/attachmentdb;create=true" userid="wso2carbon">
+                                <sql autocommit="true" driver="org.h2.Driver" onerror="continue" password="wso2carbon" url="jdbc:h2:${basedir}/target/repository/database/attachmentdb" userid="wso2carbon">
                                     <classpath>
                                         <path refid="h2.classpath" />
                                     </classpath>

--- a/components/attachment-mgt/org.wso2.carbon.attachment.mgt/src/test/resources/carbon.xml
+++ b/components/attachment-mgt/org.wso2.carbon.attachment.mgt/src/test/resources/carbon.xml
@@ -496,36 +496,4 @@
     -->
     <RequireCarbonServlet>${require.carbon.servlet}</RequireCarbonServlet>
 
-    <!--
-    Carbon H2 OSGI Configuration
-    By default non of the servers start.
-        name="web" - Start the web server with the H2 Console
-        name="webPort" - The port (default: 8082)
-        name="webAllowOthers" - Allow other computers to connect
-        name="webSSL" - Use encrypted (HTTPS) connections
-        name="tcp" - Start the TCP server
-        name="tcpPort" - The port (default: 9092)
-        name="tcpAllowOthers" - Allow other computers to connect
-        name="tcpSSL" - Use encrypted (SSL) connections
-        name="pg" - Start the PG server
-        name="pgPort"  - The port (default: 5435)
-        name="pgAllowOthers"  - Allow other computers to connect
-        name="trace" - Print additional trace information; for all servers
-        name="baseDir" - The base directory for H2 databases; for all servers  
-    -->
-    <!--H2DatabaseConfiguration>
-        <property name="web" />
-        <property name="webPort">8082</property>
-        <property name="webAllowOthers" />
-        <property name="webSSL" />
-        <property name="tcp" />
-        <property name="tcpPort">9092</property>
-        <property name="tcpAllowOthers" />
-        <property name="tcpSSL" />
-        <property name="pg" />
-        <property name="pgPort">5435</property>
-        <property name="pgAllowOthers" />
-        <property name="trace" />
-        <property name="baseDir">${carbon.home}</property>
-    </H2DatabaseConfiguration-->
 </Server>

--- a/components/bpel/org.wso2.carbon.bpel.b4p/pom.xml
+++ b/components/bpel/org.wso2.carbon.bpel.b4p/pom.xml
@@ -79,7 +79,7 @@
         </dependency>
         <dependency>
             <groupId>org.wso2.orbit.com.h2database</groupId>
-            <artifactId>h2</artifactId>
+            <artifactId>h2-engine</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.geronimo.specs</groupId>
@@ -166,7 +166,7 @@
                                 </path>
 
                                 <echo message="########### Create B4P Coordination Database ##############" />
-                                <sql autocommit="true" driver="org.h2.Driver" onerror="continue" password="" url="jdbc:h2:${basedir}/target/database/b4ph2db;create=true" userid="sa">
+                                <sql autocommit="true" driver="org.h2.Driver" onerror="continue" password="" url="jdbc:h2:${basedir}/target/database/b4ph2db" userid="sa">
                                     <classpath>
                                         <path refid="h2.classpath" />
                                     </classpath>

--- a/components/bpmn/org.wso2.carbon.bpmn.analytics.publisher/pom.xml
+++ b/components/bpmn/org.wso2.carbon.bpmn.analytics.publisher/pom.xml
@@ -48,7 +48,7 @@
         </dependency>
         <dependency>
             <groupId>org.wso2.orbit.com.h2database</groupId>
-            <artifactId>h2</artifactId>
+            <artifactId>h2-engine</artifactId>
         </dependency>
         <dependency>
             <groupId>org.mybatis</groupId>

--- a/components/humantask/org.wso2.carbon.humantask/pom.xml
+++ b/components/humantask/org.wso2.carbon.humantask/pom.xml
@@ -97,7 +97,7 @@
         </dependency>
         <dependency>
             <groupId>org.wso2.orbit.com.h2database</groupId>
-            <artifactId>h2</artifactId>
+            <artifactId>h2-engine</artifactId>
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.business-process</groupId>
@@ -150,7 +150,7 @@
                                 </path>
 
                                 <echo message="########### Create HT Database ##############" />
-                                <sql autocommit="true" driver="org.h2.Driver" onerror="continue" password="" url="jdbc:h2:${basedir}/target/database/hth2db;create=true" userid="sa">
+                                <sql autocommit="true" driver="org.h2.Driver" onerror="continue" password="" url="jdbc:h2:${basedir}/target/database/hth2db" userid="sa">
                                     <classpath>
                                         <path refid="h2.classpath" />
                                     </classpath>

--- a/components/humantask/pom.xml
+++ b/components/humantask/pom.xml
@@ -122,7 +122,7 @@
         </dependency>
         <dependency>
             <groupId>org.wso2.orbit.com.h2database</groupId>
-            <artifactId>h2</artifactId>
+            <artifactId>h2-engine</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.derby.wso2</groupId>

--- a/features/attachment-mgt/org.wso2.carbon.attachment.mgt.server.feature/pom.xml
+++ b/features/attachment-mgt/org.wso2.carbon.attachment.mgt.server.feature/pom.xml
@@ -28,7 +28,7 @@
         </dependency>
         <dependency>
             <groupId>org.wso2.orbit.com.h2database</groupId>
-            <artifactId>h2</artifactId>
+            <artifactId>h2-engine</artifactId>
         </dependency>
     </dependencies>
 
@@ -65,7 +65,7 @@
 
                                 <echo message="########### Create Attachment Mgt Database ##############" />
 
-                                <sql driver="org.h2.Driver" url="jdbc:h2:${basedir}/resources/conf/jpadb;create=true" userid="wso2carbon" password="wso2carbon" autocommit="true" onerror="continue">
+                                <sql driver="org.h2.Driver" url="jdbc:h2:${basedir}/resources/conf/jpadb" userid="wso2carbon" password="wso2carbon" autocommit="true" onerror="continue">
                                     <classpath>
                                         <path refid="h2.classpath" />
                                     </classpath>

--- a/features/attachment-mgt/org.wso2.carbon.attachment.mgt.server.feature/resources/conf/bps-datasources.xml
+++ b/features/attachment-mgt/org.wso2.carbon.attachment.mgt.server.feature/resources/conf/bps-datasources.xml
@@ -13,7 +13,7 @@
             </jndiConfig>
             <definition type="RDBMS">
                 <configuration>
-                    <url>jdbc:h2:file:./repository/database/jpadb;DB_CLOSE_ON_EXIT=FALSE;MVCC=TRUE</url>
+                    <url>jdbc:h2:file:./repository/database/jpadb;DB_CLOSE_ON_EXIT=FALSE</url>
                     <username>wso2carbon</username>
                     <password>wso2carbon</password>
                     <driverClassName>org.h2.Driver</driverClassName>

--- a/features/attachment-mgt/org.wso2.carbon.attachment.mgt.server.feature/resources/conf/datasources.properties
+++ b/features/attachment-mgt/org.wso2.carbon.attachment.mgt.server.feature/resources/conf/datasources.properties
@@ -7,7 +7,7 @@ synapse.datasources.providerPort=2199
 synapse.datasources.bpsds.registry=JNDI
 synapse.datasources.bpsds.type=BasicDataSource
 synapse.datasources.bpsds.driverClassName=org.h2.Driver
-synapse.datasources.bpsds.url=jdbc:h2:file:./repository/database/jpadb;MVCC=TRUE
+synapse.datasources.bpsds.url=jdbc:h2:file:./repository/database/jpadb
 synapse.datasources.bpsds.username=wso2carbon
 synapse.datasources.bpsds.password=wso2carbon
 synapse.datasources.bpsds.validationQuery=SELECT 1

--- a/features/bpel/org.wso2.carbon.bpel.server.feature/pom.xml
+++ b/features/bpel/org.wso2.carbon.bpel.server.feature/pom.xml
@@ -35,7 +35,7 @@
     <dependencies>
         <dependency>
             <groupId>org.wso2.orbit.com.h2database</groupId>
-            <artifactId>h2</artifactId>
+            <artifactId>h2-engine</artifactId>
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.business-process</groupId>
@@ -102,7 +102,7 @@
 
                                 <echo message="########### Create BPEL Database ##############" />
 
-                                <sql driver="org.h2.Driver" url="jdbc:h2:${basedir}/resources/conf/jpadb;create=true" userid="wso2carbon" password="wso2carbon" autocommit="true" onerror="continue">
+                                <sql driver="org.h2.Driver" url="jdbc:h2:${basedir}/resources/conf/jpadb" userid="wso2carbon" password="wso2carbon" autocommit="true" onerror="continue">
                                     <classpath>
                                         <path refid="h2.classpath" />
                                     </classpath>

--- a/features/bpel/org.wso2.carbon.bpel.server.feature/resources/conf/bps-datasources.xml
+++ b/features/bpel/org.wso2.carbon.bpel.server.feature/resources/conf/bps-datasources.xml
@@ -13,7 +13,7 @@
             </jndiConfig>
             <definition type="RDBMS">
                 <configuration>
-                    <url>jdbc:h2:file:./repository/database/jpadb;DB_CLOSE_ON_EXIT=FALSE;MVCC=TRUE</url>
+                    <url>jdbc:h2:file:./repository/database/jpadb;DB_CLOSE_ON_EXIT=FALSE</url>
                     <username>wso2carbon</username>
                     <password>wso2carbon</password>
                     <driverClassName>org.h2.Driver</driverClassName>

--- a/features/bpel/org.wso2.carbon.bpel.server.feature/resources/conf/datasources.properties
+++ b/features/bpel/org.wso2.carbon.bpel.server.feature/resources/conf/datasources.properties
@@ -7,7 +7,7 @@ synapse.datasources.providerPort=2199
 synapse.datasources.bpsds.registry=JNDI
 synapse.datasources.bpsds.type=BasicDataSource
 synapse.datasources.bpsds.driverClassName=org.h2.Driver
-synapse.datasources.bpsds.url=jdbc:h2:file:./repository/database/jpadb;MVCC=TRUE
+synapse.datasources.bpsds.url=jdbc:h2:file:./repository/database/jpadb
 synapse.datasources.bpsds.username=wso2carbon
 synapse.datasources.bpsds.password=wso2carbon
 synapse.datasources.bpsds.validationQuery=SELECT 1

--- a/features/bpmn/org.wso2.carbon.bpmn.server.feature/pom.xml
+++ b/features/bpmn/org.wso2.carbon.bpmn.server.feature/pom.xml
@@ -29,7 +29,7 @@
         </dependency>
         <dependency>
             <groupId>org.wso2.orbit.com.h2database</groupId>
-            <artifactId>h2</artifactId>
+            <artifactId>h2-engine</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -75,7 +75,7 @@
 
                                 <echo message="########### Create Activiti Database ##############" />
 
-                                <sql driver="org.h2.Driver" url="jdbc:h2:${basedir}/resources/conf/activiti;create=true" userid="wso2carbon" password="wso2carbon" autocommit="true" onerror="continue">
+                                <sql driver="org.h2.Driver" url="jdbc:h2:${basedir}/resources/conf/activiti" userid="wso2carbon" password="wso2carbon" autocommit="true" onerror="continue">
                                     <classpath>
                                         <path refid="h2.classpath" />
                                     </classpath>

--- a/features/humantask/org.wso2.carbon.humantask.server.feature/pom.xml
+++ b/features/humantask/org.wso2.carbon.humantask.server.feature/pom.xml
@@ -56,7 +56,7 @@
         </dependency>
         <dependency>
             <groupId>org.wso2.orbit.com.h2database</groupId>
-            <artifactId>h2</artifactId>
+            <artifactId>h2-engine</artifactId>
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.business-process</groupId>
@@ -97,7 +97,7 @@
 
                                 <echo message="########### Create HumanTask Database ##############" />
 
-                                <sql driver="org.h2.Driver" url="jdbc:h2:${basedir}/resources/conf/jpadb;create=true" userid="wso2carbon" password="wso2carbon" autocommit="true" onerror="continue">
+                                <sql driver="org.h2.Driver" url="jdbc:h2:${basedir}/resources/conf/jpadb" userid="wso2carbon" password="wso2carbon" autocommit="true" onerror="continue">
                                     <classpath>
                                         <path refid="h2.classpath" />
                                     </classpath>

--- a/features/humantask/org.wso2.carbon.humantask.server.feature/resources/conf/bps-datasources.xml
+++ b/features/humantask/org.wso2.carbon.humantask.server.feature/resources/conf/bps-datasources.xml
@@ -13,7 +13,7 @@
             </jndiConfig>
             <definition type="RDBMS">
                 <configuration>
-                    <url>jdbc:h2:file:./repository/database/jpadb;DB_CLOSE_ON_EXIT=FALSE;MVCC=TRUE</url>
+                    <url>jdbc:h2:file:./repository/database/jpadb;DB_CLOSE_ON_EXIT=FALSE</url>
                     <username>wso2carbon</username>
                     <password>wso2carbon</password>
                     <driverClassName>org.h2.Driver</driverClassName>

--- a/features/humantask/org.wso2.carbon.humantask.server.feature/resources/conf/datasources.properties
+++ b/features/humantask/org.wso2.carbon.humantask.server.feature/resources/conf/datasources.properties
@@ -7,7 +7,7 @@ synapse.datasources.providerPort=2199
 synapse.datasources.bpsds.registry=JNDI
 synapse.datasources.bpsds.type=BasicDataSource
 synapse.datasources.bpsds.driverClassName=org.h2.Driver
-synapse.datasources.bpsds.url=jdbc:h2:file:./repository/database/jpadb;MVCC=TRUE
+synapse.datasources.bpsds.url=jdbc:h2:file:./repository/database/jpadb
 synapse.datasources.bpsds.username=wso2carbon
 synapse.datasources.bpsds.password=wso2carbon
 synapse.datasources.bpsds.validationQuery=SELECT 1

--- a/features/humantask/org.wso2.carbon.humantask.server.feature/resources/conf/org.wso2.carbon.humantask.server.feature.default.json
+++ b/features/humantask/org.wso2.carbon.humantask.server.feature/resources/conf/org.wso2.carbon.humantask.server.feature.default.json
@@ -1,5 +1,5 @@
 {
-  "bps_database.config.url" : "jdbc:h2:file:./repository/database/jpadb;DB_CLOSE_ON_EXIT=FALSE;MVCC=TRUE",
+  "bps_database.config.url" : "jdbc:h2:file:./repository/database/jpadb;DB_CLOSE_ON_EXIT=FALSE",
   "bps_database.config.username" : "wso2carbon",
   "bps_database.config.password" : "wso2carbon",
   "bps_database.config.driver" : "org.h2.Driver"

--- a/pom.xml
+++ b/pom.xml
@@ -253,7 +253,7 @@
               </dependency>-->
             <dependency>
                 <groupId>org.wso2.orbit.com.h2database</groupId>
-                <artifactId>h2</artifactId>
+                <artifactId>h2-engine</artifactId>
                 <version>${orbit.version.h2.engine}</version>
                 <exclusions>
                     <exclusion>
@@ -1528,7 +1528,7 @@
         <geronimo-spec-javamail>1.3.0.rc51-wso2v1</geronimo-spec-javamail>
         <geronimo-spec-jms>1.1.0.rc4-wso2v1</geronimo-spec-jms>
         <orbit.version.infinispan>5.1.2.wso2v1</orbit.version.infinispan>
-        <orbit.version.h2.engine>1.4.199.wso2v1</orbit.version.h2.engine>
+        <orbit.version.h2.engine>2.1.210.wso2v1</orbit.version.h2.engine>
         <orbit.version.woden>1.0.0.M9-wso2v1</orbit.version.woden>
         <axion.wso2>1.0.0.M3-dev-wso2v1</axion.wso2>
         <tranql-connector>1.8.wso2v1</tranql-connector>


### PR DESCRIPTION
This PR: 
- Upgrades the H2 db version from 1.4.199 to 2.1.210
- Removes the MVCC configuration for compatibility with the new H2 version
- Removes the H2 console

Related to: https://github.com/wso2/product-is/issues/13162