### PR TITLE
Change Geronimo kernel to use orbit bundle

### DIFF
--- a/features/bpel/org.wso2.carbon.bpel.server.feature/pom.xml
+++ b/features/bpel/org.wso2.carbon.bpel.server.feature/pom.xml
@@ -220,7 +220,7 @@
                                 <importBundleDef>
                                     org.apache.geronimo.specs.wso2:geronimo-j2ee-connector_1.5_spec
                                 </importBundleDef>
-                                <importBundleDef>org.apache.geronimo.framework:geronimo-kernel
+                                <importBundleDef>org.apache.geronimo.modules.wso2:geronimo-kernel
                                 </importBundleDef>
                                 <importBundleDef>geronimo-spec.wso2:geronimo-spec-javamail
                                 </importBundleDef>

--- a/features/bpel/org.wso2.carbon.bpel.ui.feature/pom.xml
+++ b/features/bpel/org.wso2.carbon.bpel.ui.feature/pom.xml
@@ -110,7 +110,7 @@
                                 <importBundleDef>
                                     org.apache.geronimo.specs.wso2:geronimo-j2ee-connector_1.5_spec
                                 </importBundleDef>
-                                <importBundleDef>org.apache.geronimo.framework:geronimo-kernel
+                                <importBundleDef>org.apache.geronimo.modules.wso2:geronimo-kernel
                                 </importBundleDef>
                                 <importBundleDef>geronimo-spec.wso2:geronimo-spec-javamail
                                 </importBundleDef>

--- a/features/bpel/pom.xml
+++ b/features/bpel/pom.xml
@@ -119,7 +119,7 @@
                 <artifactId>geronimo-j2ee-connector_1.5_spec</artifactId>
             </dependency>
             <dependency>
-                <groupId>org.apache.geronimo.framework</groupId>
+                <groupId>org.apache.geronimo.modules.wso2</groupId>
                 <artifactId>geronimo-kernel</artifactId>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -862,7 +862,7 @@
                 <version>${geronimo.j2ee.connector.1.5.spec.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.geronimo.framework</groupId>
+                <groupId>org.apache.geronimo.modules.wso2</groupId>
                 <artifactId>geronimo-kernel</artifactId>
                 <version>${geronimo-kernel}</version>
             </dependency>
@@ -1524,7 +1524,7 @@
         <!--jxl.wso2.version>2.6.8.wso2v1</jxl.wso2.version-->
         <junit.version>3.8.2</junit.version>
         <wsdl4j.wso2.version>1.6.2.wso2v4</wsdl4j.wso2.version>
-        <geronimo-kernel>3.0.1</geronimo-kernel>
+        <geronimo-kernel>3.0.1.wso2v1</geronimo-kernel>
         <geronimo-spec-javamail>1.3.0.rc51-wso2v1</geronimo-spec-javamail>
         <geronimo-spec-jms>1.1.0.rc4-wso2v1</geronimo-spec-jms>
         <orbit.version.infinispan>5.1.2.wso2v1</orbit.version.infinispan>


### PR DESCRIPTION
## Purpose
The orbit based geronimo-kernel bundle does not require xstream 1.3 library. The need for this arise after the xstream version update. https://github.com/wso2/carbon-business-process/pull/664

Resolves - https://github.com/wso2/product-is/issues/13598