### PR TITLE
Change mismatched permission name

### DIFF
--- a/components/attachment-mgt/org.wso2.carbon.attachment.mgt/src/main/resources/META-INF/component.xml
+++ b/components/attachment-mgt/org.wso2.carbon.attachment.mgt/src/main/resources/META-INF/component.xml
@@ -22,7 +22,7 @@
             <ResourceId>/permission/admin/manage/attachment</ResourceId>
         </ManagementPermission>
         <ManagementPermission>
-            <DisplayName>Monitor BPEL</DisplayName>
+            <DisplayName>Monitor Attachment</DisplayName>
             <ResourceId>/permission/admin/monitor/attachment</ResourceId>
         </ManagementPermission>
     </ManagementPermissions>


### PR DESCRIPTION
## Purpose
> The permission display name `Monitor BPEL` has been duplicated twice for two different resource paths i.e. `/permission/admin/monitor/bpel` and `/permission/admin/monitor/attachment`. Considering these two paths, the display name for `/permission/admin/monitor/attachment` is renamed to `Monitor Attachment`.

## Related Issues
> Issue https://github.com/wso2/product-is/issues/14009

## Related PRs
> 