### PR TITLE
Update h2-engine dependency version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1539,7 +1539,7 @@
         <geronimo-spec-javamail>1.3.0.rc51-wso2v1</geronimo-spec-javamail>
         <geronimo-spec-jms>1.1.0.rc4-wso2v1</geronimo-spec-jms>
         <orbit.version.infinispan>5.1.2.wso2v1</orbit.version.infinispan>
-        <orbit.version.h2.engine>2.1.210.wso2v1</orbit.version.h2.engine>
+        <orbit.version.h2.engine>2.2.220.wso2v1</orbit.version.h2.engine>
         <orbit.version.woden>1.0.0.M9-wso2v1</orbit.version.woden>
         <axion.wso2>1.0.0.M3-dev-wso2v1</axion.wso2>
         <tranql-connector>1.8.wso2v1</tranql-connector>


### PR DESCRIPTION
## Purpose
Upgrade the `org.wso2.orbit.com.h2database:h2-engine` to 2.2.220.wso2v1

Merge after https://github.com/wso2/orbit/pull/994 is merged and released